### PR TITLE
Add XSBench as target, with CUDA, OMP, Kokkos versions

### DIFF
--- a/targets/XSBench/cuda/CMakeLists.txt
+++ b/targets/XSBench/cuda/CMakeLists.txt
@@ -1,0 +1,23 @@
+cmake_minimum_required(VERSION 3.21)
+
+project(
+    XSBench_CUDA
+    VERSION 1.0
+    LANGUAGES CXX CUDA
+)
+
+if(NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE Release)
+endif()
+
+set(CMAKE_CXX_FLAGS "-Wall -Wextra")
+set(CMAKE_CXX_FLAGS_DEBUG "-g")
+set(CMAKE_CXX_FLAGS_RELEASE "-O3")
+
+set(SOURCE Main.cu io.cu Simulation.cu GridInit.cu XSutils.cu Materials.cu)
+
+set_source_files_properties(${SOURCE} PROPERTIES LANGUAGE CUDA)
+
+add_executable(XSBench ${SOURCE})
+
+install(TARGETS XSBench DESTINATION bin)

--- a/targets/XSBench/cuda/GridInit.cu
+++ b/targets/XSBench/cuda/GridInit.cu
@@ -1,0 +1,282 @@
+#include "XSbench_header.cuh"
+
+// Moves all required data structures to the GPU's memory space
+SimulationData move_simulation_data_to_device( Inputs in, int mype, SimulationData SD )
+{
+        if(mype == 0) printf("Allocating and moving simulation data to GPU memory space...\n");
+
+        ////////////////////////////////////////////////////////////////////////////////
+        // SUMMARY: Simulation Data Structure Manifest for "SD" Object
+        // Here we list all heap arrays (and lengths) in SD that would need to be
+        // offloaded manually if using an accelerator with a seperate memory space
+        ////////////////////////////////////////////////////////////////////////////////
+        // int * num_nucs;                     // Length = length_num_nucs;
+        // double * concs;                     // Length = length_concs
+        // int * mats;                         // Length = length_mats
+        // double * unionized_energy_array;    // Length = length_unionized_energy_array
+        // int * index_grid;                   // Length = length_index_grid
+        // NuclideGridPoint * nuclide_grid;    // Length = length_nuclide_grid
+        //
+        // Note: "unionized_energy_array" and "index_grid" can be of zero length
+        //        depending on lookup method.
+        //
+        // Note: "Lengths" are given as the number of objects in the array, not the
+        //       number of bytes.
+        ////////////////////////////////////////////////////////////////////////////////
+        size_t sz;
+        size_t total_sz = 0;
+
+        // Shallow copy of CPU simulation data to GPU simulation data
+        SimulationData GSD = SD;
+
+        // Move data to GPU memory space
+        sz = GSD.length_num_nucs * sizeof(int);
+        gpuErrchk( cudaMalloc((void **) &GSD.num_nucs, sz) );
+        gpuErrchk( cudaMemcpy(GSD.num_nucs, SD.num_nucs, sz, cudaMemcpyHostToDevice) );
+        total_sz += sz;
+
+        sz = GSD.length_concs * sizeof(double);
+        gpuErrchk( cudaMalloc((void **) &GSD.concs, sz) );
+        gpuErrchk( cudaMemcpy(GSD.concs, SD.concs, sz, cudaMemcpyHostToDevice) );
+        total_sz += sz;
+
+        sz = GSD.length_mats * sizeof(int);
+        gpuErrchk( cudaMalloc((void **) &GSD.mats, sz) );
+        gpuErrchk( cudaMemcpy(GSD.mats, SD.mats, sz, cudaMemcpyHostToDevice) );
+        total_sz += sz;
+
+        if (SD.length_unionized_energy_array != 0) {
+                sz = GSD.length_unionized_energy_array * sizeof(double);
+                gpuErrchk( cudaMalloc((void **) &GSD.unionized_energy_array, sz) );
+                gpuErrchk( cudaMemcpy(GSD.unionized_energy_array, SD.unionized_energy_array, sz, cudaMemcpyHostToDevice) );
+                total_sz += sz;
+        }
+
+        if (SD.length_index_grid != 0) {
+                sz = GSD.length_index_grid * sizeof(int);
+                gpuErrchk( cudaMalloc((void **) &GSD.index_grid, sz) );
+                gpuErrchk( cudaMemcpy(GSD.index_grid, SD.index_grid, sz, cudaMemcpyHostToDevice) );
+                total_sz += sz;
+        }
+
+        sz = GSD.length_nuclide_grid * sizeof(NuclideGridPoint);
+        gpuErrchk( cudaMalloc((void **) &GSD.nuclide_grid, sz) );
+        gpuErrchk( cudaMemcpy(GSD.nuclide_grid, SD.nuclide_grid, sz, cudaMemcpyHostToDevice) );
+        total_sz += sz;
+
+        // Allocate verification array on device. This structure is not needed on CPU, so we don't
+        // have to copy anything over.
+        sz = in.lookups * sizeof(unsigned long);
+        gpuErrchk( cudaMalloc((void **) &GSD.verification, sz) );
+        total_sz += sz;
+        GSD.length_verification = in.lookups;
+
+        // Synchronize
+        gpuErrchk( cudaPeekAtLastError() );
+        gpuErrchk( cudaDeviceSynchronize() );
+
+        if(mype == 0 ) printf("GPU Intialization complete. Allocated %.0lf MB of data on GPU.\n", total_sz/1024.0/1024.0 );
+
+        return GSD;
+
+}
+
+// Release device memory
+void release_device_memory(SimulationData GSD) {
+        cudaFree(GSD.num_nucs);
+        cudaFree(GSD.concs);
+        cudaFree(GSD.mats);
+        if (GSD.length_unionized_energy_array > 0) cudaFree(GSD.unionized_energy_array);
+        cudaFree(GSD.nuclide_grid);
+        cudaFree(GSD.verification);
+}
+
+void release_memory(SimulationData SD) {
+        free(SD.num_nucs);
+        free(SD.concs);
+        free(SD.mats);
+        if (SD.length_unionized_energy_array > 0) free(SD.unionized_energy_array);
+        free(SD.nuclide_grid);
+        free(SD.verification);
+}
+
+SimulationData grid_init_do_not_profile( Inputs in, int mype )
+{
+        // Structure to hold all allocated simuluation data arrays
+        SimulationData SD;
+
+
+
+        // Keep track of how much data we're allocating
+        size_t nbytes = 0;
+
+        // Set the initial seed value
+        uint64_t seed = 42;
+
+        ////////////////////////////////////////////////////////////////////
+        // Initialize Nuclide Grids
+        ////////////////////////////////////////////////////////////////////
+
+        if(mype == 0) printf("Intializing nuclide grids...\n");
+
+        // First, we need to initialize our nuclide grid. This comes in the form
+        // of a flattened 2D array that hold all the information we need to define
+        // the cross sections for all isotopes in the simulation.
+        // The grid is composed of "NuclideGridPoint" structures, which hold the
+        // energy level of the grid point and all associated XS data at that level.
+        // An array of structures (AOS) is used instead of
+        // a structure of arrays, as the grid points themselves are accessed in
+        // a random order, but all cross section interaction channels and the
+        // energy level are read whenever the gridpoint is accessed, meaning the
+        // AOS is more cache efficient.
+
+        // Initialize Nuclide Grid
+        SD.length_nuclide_grid = in.n_isotopes * in.n_gridpoints;
+        SD.nuclide_grid     = (NuclideGridPoint *) malloc( SD.length_nuclide_grid * sizeof(NuclideGridPoint));
+        assert(SD.nuclide_grid != NULL);
+        nbytes += SD.length_nuclide_grid * sizeof(NuclideGridPoint);
+        for( int i = 0; i < SD.length_nuclide_grid; i++ )
+        {
+                SD.nuclide_grid[i].energy        = LCG_random_double(&seed);
+                SD.nuclide_grid[i].total_xs      = LCG_random_double(&seed);
+                SD.nuclide_grid[i].elastic_xs    = LCG_random_double(&seed);
+                SD.nuclide_grid[i].absorbtion_xs = LCG_random_double(&seed);
+                SD.nuclide_grid[i].fission_xs    = LCG_random_double(&seed);
+                SD.nuclide_grid[i].nu_fission_xs = LCG_random_double(&seed);
+        }
+
+        // Sort so that each nuclide has data stored in ascending energy order.
+        for( int i = 0; i < in.n_isotopes; i++ )
+                qsort( &SD.nuclide_grid[i*in.n_gridpoints], in.n_gridpoints, sizeof(NuclideGridPoint), NGP_compare);
+
+        // error debug check
+        /*
+        for( int i = 0; i < in.n_isotopes; i++ )
+        {
+                printf("NUCLIDE %d ==============================\n", i);
+                for( int j = 0; j < in.n_gridpoints; j++ )
+                printf("E%d = %lf\n", j, SD.nuclide_grid[i * in.n_gridpoints + j].energy);
+        }
+        */
+
+        // Allocate Verification Array
+        size_t sz = in.lookups * sizeof(unsigned long);
+        SD.verification = (unsigned long *) malloc(sz);
+        nbytes += sz;
+
+
+        ////////////////////////////////////////////////////////////////////
+        // Initialize Acceleration Structure
+        ////////////////////////////////////////////////////////////////////
+
+        if( in.grid_type == NUCLIDE )
+        {
+                SD.length_unionized_energy_array = 0;
+                SD.length_index_grid = 0;
+        }
+
+        if( in.grid_type == UNIONIZED )
+        {
+                if(mype == 0) printf("Intializing unionized grid...\n");
+
+                // Allocate space to hold the union of all nuclide energy data
+                SD.length_unionized_energy_array = in.n_isotopes * in.n_gridpoints;
+                SD.unionized_energy_array = (double *) malloc( SD.length_unionized_energy_array * sizeof(double));
+                assert(SD.unionized_energy_array != NULL );
+                nbytes += SD.length_unionized_energy_array * sizeof(double);
+
+                // Copy energy data over from the nuclide energy grid
+                for( int i = 0; i < SD.length_unionized_energy_array; i++ )
+                        SD.unionized_energy_array[i] = SD.nuclide_grid[i].energy;
+
+                // Sort unionized energy array
+                qsort( SD.unionized_energy_array, SD.length_unionized_energy_array, sizeof(double), double_compare);
+
+                // Allocate space to hold the acceleration grid indices
+                SD.length_index_grid = SD.length_unionized_energy_array * in.n_isotopes;
+                SD.index_grid = (int *) malloc( SD.length_index_grid * sizeof(int));
+                assert(SD.index_grid != NULL);
+                nbytes += SD.length_index_grid * sizeof(int);
+
+                // Generates the double indexing grid
+                int * idx_low = (int *) calloc( in.n_isotopes, sizeof(int));
+                assert(idx_low != NULL );
+                double * energy_high = (double *) malloc( in.n_isotopes * sizeof(double));
+                assert(energy_high != NULL );
+
+                for( int i = 0; i < in.n_isotopes; i++ )
+                        energy_high[i] = SD.nuclide_grid[i * in.n_gridpoints + 1].energy;
+
+                for( long e = 0; e < SD.length_unionized_energy_array; e++ )
+                {
+                        double unionized_energy = SD.unionized_energy_array[e];
+                        for( long i = 0; i < in.n_isotopes; i++ )
+                        {
+                                if( unionized_energy < energy_high[i]  )
+                                        SD.index_grid[e * in.n_isotopes + i] = idx_low[i];
+                                        else if( idx_low[i] == in.n_gridpoints - 2 )
+                                        SD.index_grid[e * in.n_isotopes + i] = idx_low[i];
+                                        else
+                                        {
+                                        idx_low[i]++;
+                                        SD.index_grid[e * in.n_isotopes + i] = idx_low[i];
+                                        energy_high[i] = SD.nuclide_grid[i * in.n_gridpoints + idx_low[i] + 1].energy;
+                                }
+                        }
+                }
+
+                free(idx_low);
+                free(energy_high);
+        }
+
+        if( in.grid_type == HASH )
+        {
+                if(mype == 0) printf("Intializing hash grid...\n");
+                SD.length_unionized_energy_array = 0;
+                SD.length_index_grid  = in.hash_bins * in.n_isotopes;
+                SD.index_grid = (int *) malloc( SD.length_index_grid * sizeof(int));
+                assert(SD.index_grid != NULL);
+                nbytes += SD.length_index_grid * sizeof(int);
+
+                double du = 1.0 / in.hash_bins;
+
+                // For each energy level in the hash table
+                for( long e = 0; e < in.hash_bins; e++ )
+                {
+                        double energy = e * du;
+
+                        // We need to determine the bounding energy levels for all isotopes
+                        for( long i = 0; i < in.n_isotopes; i++ )
+                        {
+                                SD.index_grid[e * in.n_isotopes + i] = grid_search_nuclide( in.n_gridpoints, energy, SD.nuclide_grid + i * in.n_gridpoints, 0, in.n_gridpoints-1);
+                        }
+                }
+        }
+
+        ////////////////////////////////////////////////////////////////////
+        // Initialize Materials and Concentrations
+        ////////////////////////////////////////////////////////////////////
+        if(mype == 0) printf("Intializing material data...\n");
+
+        // Set the number of nuclides in each material
+        SD.num_nucs  = load_num_nucs(in.n_isotopes);
+        SD.length_num_nucs = 12; // There are always 12 materials in XSBench
+
+        // Intialize the flattened 2D grid of material data. The grid holds
+        // a list of nuclide indices for each of the 12 material types. The
+        // grid is allocated as a full square grid, even though not all
+        // materials have the same number of nuclides.
+        SD.mats = load_mats(SD.num_nucs, in.n_isotopes, &SD.max_num_nucs);
+        SD.length_mats = SD.length_num_nucs * SD.max_num_nucs;
+
+        // Intialize the flattened 2D grid of nuclide concentration data. The grid holds
+        // a list of nuclide concentrations for each of the 12 material types. The
+        // grid is allocated as a full square grid, even though not all
+        // materials have the same number of nuclides.
+        SD.concs = load_concs(SD.num_nucs, SD.max_num_nucs);
+        SD.length_concs = SD.length_mats;
+
+        if(mype == 0) printf("Intialization complete. Allocated %.0lf MB of data on CPU.\n", nbytes/1024.0/1024.0 );
+
+        return SD;
+}

--- a/targets/XSBench/cuda/Main.cu
+++ b/targets/XSBench/cuda/Main.cu
@@ -1,0 +1,107 @@
+#include "XSbench_header.cuh"
+
+int main(int argc, char *argv[]) {
+        // =====================================================================
+        // Initialization & Command Line Read-In
+        // =====================================================================
+        int version = 20;
+        int mype = 0;
+        double omp_start, omp_end;
+        int nprocs = 1;
+        unsigned long long verification;
+
+        // Process CLI Fields -- store in "Inputs" structure
+        Inputs in = read_CLI(argc, argv);
+
+        // Print-out of Input Summary
+        if (mype == 0)
+                print_inputs(in, nprocs, version);
+
+        // =====================================================================
+        // Prepare Nuclide Energy Grids, Unionized Energy Grid, & Material Data
+        // This is not reflective of a real Monte Carlo simulation workload,
+        // therefore, do not profile this region!
+        // =====================================================================
+
+        SimulationData SD;
+
+        // If read from file mode is selected, skip initialization and load
+        // all simulation data structures from file instead
+        if (in.binary_mode == READ)
+                SD = binary_read(in);
+        else
+                SD = grid_init_do_not_profile(in, mype);
+
+        // If writing from file mode is selected, write all simulation data
+        // structures to file
+        if (in.binary_mode == WRITE && mype == 0)
+                binary_write(in, SD);
+
+	Profile profile;
+
+        // =====================================================================
+        // Cross Section (XS) Parallel Lookup Simulation
+        // This is the section that should be profiled, as it reflects a
+        // realistic continuous energy Monte Carlo macroscopic cross section
+        // lookup kernel.
+        // =====================================================================
+        if (mype == 0) {
+                printf("\n");
+                border_print();
+                center_print("SIMULATION", 79);
+                border_print();
+        }
+
+        // Start Simulation Timer
+        omp_start = get_time();
+
+        // Run simulation
+        if (in.simulation_method == EVENT_BASED) {
+                if (in.kernel_id == 0)
+                        verification = run_event_based_simulation_baseline(in, SD, mype, &profile);
+                else if (in.kernel_id == 1)
+                        verification = run_event_based_simulation_optimization_1(in, SD, mype);
+                else if (in.kernel_id == 2)
+                        verification = run_event_based_simulation_optimization_2(in, SD, mype);
+                else if (in.kernel_id == 3)
+                        verification = run_event_based_simulation_optimization_3(in, SD, mype);
+                else if (in.kernel_id == 4)
+                        verification = run_event_based_simulation_optimization_4(in, SD, mype);
+                else if (in.kernel_id == 5)
+                        verification = run_event_based_simulation_optimization_5(in, SD, mype);
+                else if (in.kernel_id == 6)
+                        verification = run_event_based_simulation_optimization_6(in, SD, mype);
+                else {
+                        printf("Error: No kernel ID %d found!\n", in.kernel_id);
+                        exit(1);
+                }
+        } else {
+                printf(
+                        "History-based simulation not implemented in CUDA code. Instead,\nuse "
+                        "the event-based method with \"-m event\" argument.\n");
+                exit(1);
+        }
+
+        if (mype == 0) {
+                printf("\n");
+                printf("Simulation complete.\n");
+        }
+
+
+        // End Simulation Timer
+        omp_end = get_time();
+
+        // Release device memory
+        release_memory(SD);
+
+        // Final Hash Step
+        verification = verification % 999983;
+
+        // Print / Save Results and Exit
+        int is_invalid_result =
+                print_results(in, mype, omp_end - omp_start, nprocs, verification);
+
+	print_profile(profile, in);
+
+	return is_invalid_result;
+}

--- a/targets/XSBench/cuda/Makefile
+++ b/targets/XSBench/cuda/Makefile
@@ -1,0 +1,77 @@
+#===============================================================================
+# User Options
+#===============================================================================
+
+COMPILER    ?= nvidia
+OPTIMIZE    ?= yes
+DEBUG       ?= no
+PROFILE     ?= no
+SM_VERSION  ?= 80
+
+#===============================================================================
+# Program name & source code list
+#===============================================================================
+
+program = XSBench
+
+source = \
+Main.cu \
+io.cu \
+Simulation.cu \
+GridInit.cu \
+XSutils.cu \
+Materials.cu
+
+obj = $(source:.cu=.o)
+
+#===============================================================================
+# Sets Flags
+#===============================================================================
+
+# Standard Flags
+CFLAGS := 
+
+# Linker Flags
+LDFLAGS = -lm
+
+# NVIDIA Compiler
+ifeq ($(COMPILER),nvidia)
+  CC = nvcc
+  CFLAGS += -Xcompiler -Wall -Xcompiler -O3 -arch=sm_$(SM_VERSION) -std=c++14
+endif
+
+# Debug Flags
+ifeq ($(DEBUG),yes)
+  CFLAGS += -g -G
+  LDFLAGS  += -g -G
+endif
+
+# Profiling Flags
+ifeq ($(PROFILE),yes)
+  CFLAGS += -pg
+  LDFLAGS  += -pg
+endif
+
+# Optimization Flags
+ifeq ($(OPTIMIZE),yes)
+  CFLAGS += -O3
+endif
+
+#===============================================================================
+# Targets to Build
+#===============================================================================
+
+$(program): $(obj) XSbench_header.cuh Makefile
+	$(CC) $(CFLAGS) $(obj) -o $@ $(LDFLAGS)
+
+%.o: %.cu XSbench_header.cuh Makefile
+	$(CC) $(CFLAGS) -c $< -o $@
+
+clean:
+	rm -rf $(program) $(obj)
+
+edit:
+	vim -p $(source) XSbench_header.cuh
+
+run:
+	./$(program)

--- a/targets/XSBench/cuda/Materials.cu
+++ b/targets/XSBench/cuda/Materials.cu
@@ -1,0 +1,116 @@
+// Material data is hard coded into the functions in this file.
+// Note that there are 12 materials present in H-M (large or small)
+
+#include "XSbench_header.cuh"
+
+// num_nucs represents the number of nuclides that each material contains
+int * load_num_nucs(long n_isotopes)
+{
+        int * num_nucs = (int*)malloc(12*sizeof(int));
+
+        // Material 0 is a special case (fuel). The H-M small reactor uses
+        // 34 nuclides, while H-M larges uses 300.
+        if( n_isotopes == 68 )
+                num_nucs[0]  = 34; // HM Small is 34, H-M Large is 321
+        else
+                num_nucs[0]  = 321; // HM Small is 34, H-M Large is 321
+
+        num_nucs[1]  = 5;
+        num_nucs[2]  = 4;
+        num_nucs[3]  = 4;
+        num_nucs[4]  = 27;
+        num_nucs[5]  = 21;
+        num_nucs[6]  = 21;
+        num_nucs[7]  = 21;
+        num_nucs[8]  = 21;
+        num_nucs[9]  = 21;
+        num_nucs[10] = 9;
+        num_nucs[11] = 9;
+
+        return num_nucs;
+}
+
+// Assigns an array of nuclide ID's to each material
+int * load_mats( int * num_nucs, long n_isotopes, int * max_num_nucs )
+{
+        *max_num_nucs = 0;
+        int num_mats = 12;
+        for( int m = 0; m < num_mats; m++ )
+        {
+                if( num_nucs[m] > *max_num_nucs )
+                        *max_num_nucs = num_nucs[m];
+        }
+        int * mats = (int *) malloc( num_mats * (*max_num_nucs) * sizeof(int) );
+
+        // Small H-M has 34 fuel nuclides
+        int mats0_Sml[] =  { 58, 59, 60, 61, 40, 42, 43, 44, 45, 46, 1, 2, 3, 7,
+                8, 9, 10, 29, 57, 47, 48, 0, 62, 15, 33, 34, 52, 53, 
+                54, 55, 56, 18, 23, 41 }; //fuel
+        // Large H-M has 300 fuel nuclides
+        int mats0_Lrg[321] =  { 58, 59, 60, 61, 40, 42, 43, 44, 45, 46, 1, 2, 3, 7,
+                8, 9, 10, 29, 57, 47, 48, 0, 62, 15, 33, 34, 52, 53,
+                54, 55, 56, 18, 23, 41 }; //fuel
+        for( int i = 0; i < 321-34; i++ )
+                mats0_Lrg[34+i] = 68 + i; // H-M large adds nuclides to fuel only
+
+        // These are the non-fuel materials	
+        int mats1[] =  { 63, 64, 65, 66, 67 }; // cladding
+        int mats2[] =  { 24, 41, 4, 5 }; // cold borated water
+        int mats3[] =  { 24, 41, 4, 5 }; // hot borated water
+        int mats4[] =  { 19, 20, 21, 22, 35, 36, 37, 38, 39, 25, 27, 28, 29,
+                30, 31, 32, 26, 49, 50, 51, 11, 12, 13, 14, 6, 16,
+        17 }; // RPV
+        int mats5[] =  { 24, 41, 4, 5, 19, 20, 21, 22, 35, 36, 37, 38, 39, 25,
+                49, 50, 51, 11, 12, 13, 14 }; // lower radial reflector
+        int mats6[] =  { 24, 41, 4, 5, 19, 20, 21, 22, 35, 36, 37, 38, 39, 25,
+                49, 50, 51, 11, 12, 13, 14 }; // top reflector / plate
+        int mats7[] =  { 24, 41, 4, 5, 19, 20, 21, 22, 35, 36, 37, 38, 39, 25,
+                49, 50, 51, 11, 12, 13, 14 }; // bottom plate
+        int mats8[] =  { 24, 41, 4, 5, 19, 20, 21, 22, 35, 36, 37, 38, 39, 25,
+                49, 50, 51, 11, 12, 13, 14 }; // bottom nozzle
+        int mats9[] =  { 24, 41, 4, 5, 19, 20, 21, 22, 35, 36, 37, 38, 39, 25,
+                49, 50, 51, 11, 12, 13, 14 }; // top nozzle
+        int mats10[] = { 24, 41, 4, 5, 63, 64, 65, 66, 67 }; // top of FA's
+        int mats11[] = { 24, 41, 4, 5, 63, 64, 65, 66, 67 }; // bottom FA's
+
+        // H-M large v small dependency
+        if( n_isotopes == 68 )
+                memcpy( mats,  mats0_Sml,  num_nucs[0]  * sizeof(int) );	
+        else
+                memcpy( mats,  mats0_Lrg,  num_nucs[0]  * sizeof(int) );
+
+        // Copy other materials
+        memcpy( mats + *max_num_nucs * 1,  mats1,  num_nucs[1]  * sizeof(int) );	
+        memcpy( mats + *max_num_nucs * 2,  mats2,  num_nucs[2]  * sizeof(int) );	
+        memcpy( mats + *max_num_nucs * 3,  mats3,  num_nucs[3]  * sizeof(int) );	
+        memcpy( mats + *max_num_nucs * 4,  mats4,  num_nucs[4]  * sizeof(int) );	
+        memcpy( mats + *max_num_nucs * 5,  mats5,  num_nucs[5]  * sizeof(int) );	
+        memcpy( mats + *max_num_nucs * 6,  mats6,  num_nucs[6]  * sizeof(int) );	
+        memcpy( mats + *max_num_nucs * 7,  mats7,  num_nucs[7]  * sizeof(int) );	
+        memcpy( mats + *max_num_nucs * 8,  mats8,  num_nucs[8]  * sizeof(int) );	
+        memcpy( mats + *max_num_nucs * 9,  mats9,  num_nucs[9]  * sizeof(int) );	
+        memcpy( mats + *max_num_nucs * 10, mats10, num_nucs[10] * sizeof(int) );	
+        memcpy( mats + *max_num_nucs * 11, mats11, num_nucs[11] * sizeof(int) );	
+
+        return mats;
+}
+
+// Randomizes the concentrations of all nuclides in a variety of materials
+double * load_concs( int * num_nucs, int max_num_nucs )
+{
+        uint64_t seed = STARTING_SEED * STARTING_SEED;
+        double * concs = (double *) malloc( 12 * max_num_nucs * sizeof( double ) );
+
+        for( int i = 0; i < 12; i++ )
+                for( int j = 0; j < num_nucs[i]; j++ )
+                        concs[i * max_num_nucs + j] = LCG_random_double(&seed);
+
+        // test
+        /*
+    for( int i = 0; i < 12; i++ )
+        for( int j = 0; j < num_nucs[i]; j++ )
+            printf("concs[%d][%d] = %lf\n", i, j, concs[i][j] );
+        */
+
+        return concs;
+}

--- a/targets/XSBench/cuda/README.md
+++ b/targets/XSBench/cuda/README.md
@@ -1,0 +1,248 @@
+![XSBench](docs/img/logo.png)
+
+[![Latest Github release](https://img.shields.io/github/release/ANL-CESAR/XSBench.svg)](https://github.com/ANL-CESAR/XSBench/releases/latest)
+[![Build Status](https://travis-ci.com/ANL-CESAR/XSBench.svg?branch=master)](https://travis-ci.com/ANL-CESAR/XSBench)
+[![Published in Annals of Nuclear Energy](https://img.shields.io/badge/Published%20in-Annals%20of%20Nuclear%20Energy-167DA4.svg)](https://www.sciencedirect.com/science/article/pii/S0306454914004332)
+
+XSBench is a mini-app representing a key computational kernel of the Monte Carlo neutron transport algorithm. Specifically, XSBench represents the continuous energy macroscopic neutron cross section lookup kernel. XSBench serves as a lightweight stand-in for full neutron transport applications like [OpenMC](https://github.com/openmc-dev/openmc), and is a useful tool for performance analysis on high performance computing architectures.
+
+## Table of Contents
+
+1. [Compilation](#Compilation)
+2. [Running XSBench / Command Line Interface](#Running-XSBench)
+3. [Feature Discussion](#Feature-Discussion)
+	* [MPI Support](#MPI-Support)
+	* [Verification Support](#Verification-Support)
+	* [Binary File Support](#Binary-File-Support)
+4. [Theory & Algorithms](#Algorithms)
+	* [Transport Simulation Styles](#Transport-Simulation-Styles)
+		- [History-Based Transport](#History-Based-Transport)
+		- [Event-Based Transport](#Event-Based-Transport)
+	* [Cross Section Lookup Methods](#Cross-Section-Lookup-Methods)
+		- [Nuclide Grid](#Nuclide-Grid)
+		- [Unionized Energy Grid](#Unionized-Energy-Grid)
+		- [Logarithmic Hash Grid](#Logarithmic-Hash-Grid)
+5. [Optimized Kernels](#Optimized-Kernels)
+6. [Citing XSBench](#Citing-XSBench)
+7. [Development Team](#Development-Team) 
+
+XSBench has been implemented in CUDA for use with NVIDIA GPU architectures. NOTE: You will likely want to specify in the makefile or the command line when using make the SM version for the card you are running on.
+
+## Compilation
+
+To compile XSBench with default settings, navigate to your selected source directory and use the following command:
+
+```bash
+make
+```
+ 
+ You can alter compiler settings in the included Makefile.
+
+### Debugging, Optimization & Profiling
+
+There are also a number of switches that can be set in the makefile. Here is a sample of the control panel at the top of the makefile:
+
+```make
+OPTIMIZE = yes
+DEBUG    = no
+PROFILE  = no
+MPI      = no
+```
+- Optimization enables the -O3 optimization flag.
+- Debugging enables the -g flag.
+- Profiling enables the -pg flag. When profiling the code, you may
+wish to significantly increase the number of lookups (with the -l
+flag) in order to wash out the initialization phase of the code.
+- MPI enables MPI support in the code.
+
+## Running XSBench
+
+To run XSBench with default settings, use the following command:
+```bash
+./XSBench
+```
+For non-default settings, XSBench supports the following command line options:
+
+| Argument    |Description | Options     | Default
+|-------------|------------|---------------|------------|
+|-m           |Simulation method| history, event| history|
+|-s | Problem Size | small, large, XL, XXL | large|
+|-g | # of gridpoints per nuclide (overrides -s defaults) | integer value| 11,303 |
+-G | Grid search type | unionized, nuclide, hash | unionized |
+-p | # of particle histories (if running using "history" method)| integer value | 500,000 |
+-l | # of Cross-section (XS) lookups. If using history based method, this is lookups per particle history. If using event-based method, this is total lookups. | integer value | (History: 34) (Event: 17,000,000) |
+-h | # of hash bins (only used with hash-based grid search) | integer value | 10,000 |
+-b | Read/Write binary files | read, write |  |
+-k | Optimized kernel ID | integer value | 0
+
+- **-m [simulation method]**
+Sets the simulation method, either "history" or "event". These options represent the history based or event based algorithms respectively. The default is the history based method. These two methods represent different methods of parallelizing the Monte Carlo transport method. In the history based method, the central mode of parallelism is expressed over particles, which each require some number of macroscopic cross sections to be executed in series and in a dependent order. The event based method expresses its parallelism over a large pool of independent macroscopic cross section lookups that can be executed in any order without dependence. They key difference between the two methods is the dependence/independence of the macroscopic cross section loop. See the [Transport Simulation Styles](#Transport-Simulation-Styles) section for more information.
+
+- **-s [size]**
+Sets the size of the Hoogenboom-Martin reactor model. There are four options: 'small', 'large', 'XL', and 'XXL'. By default, the 'large' option is selected. The H-M size corresponds to the number of nuclides present in the fuel region. The small version has 34 fuel nuclides, whereas the large version has 321 fuel nuclides. This significantly slows down the runtime of the program as the data structures are much larger, and more lookups are required whenever a lookup occurs in a fuel material. Note that the program defaults to "Large" if no specification is made. The additional size options, "XL" and "XXL", do not directly correspond to any particular physical model. They are similar to the H-M "large" option, except the number of gridpoints per nuclide has been increased greatly. This creates an extremely large energy grid data structure (XL: 120GB, XXL: 252GB), which is unlikely to fit on a single node, but is useful for experimentation purposes on novel architectures.
+
+- **-g [gridpoints]**
+Sets the number of gridpoints per nuclide. By default, this value is set to 11,303. This corresponds to the average number of actual gridpoints per nuclide in the H-M Large model as run by OpenMC with the actual ACE ENDF cross-section data. Note that this option will override the number of default gridpoints as set by the '-s' option.
+
+- **-G [grid type]**
+Sets the grid search type (unionized, nuclide, hash). Defaults to unionized. The unionized grid is what is typically used in Monte Carlo codes, as it offers the fastest speed. However, the increase in speed comes in a significant increase in memory usage as a union of all the separate nuclide grids must be formed and stored in memory. The "nuclide" mode uses only the basic nuclide grid data, with no unionization. This is slower as a binary search must be performed on every nuclide for each macroscopic XS lookup, rather than only once when using the unionized grid. Finally, the "hash" mode is a newer algorithm now used by many full Monte Carlo codes which offers speed nearly equivalent to the unionized energy grid method, but with only a small fraction of the memory overhead. See the [Cross Section Lookup Methods](#Cross-Section-Lookup-Methods) section for more details.
+
+- **-p [particles]**
+Sets the number of particle histories to simulate. By default, this value is set to 500,000. Users may want to increase this value if they wish to extend the runtime of XSBench, perhaps to produce more reliable performance counter data - as extending the run will decrease the percentage of runtime spent on initialization. Real MC simulations in a full application may use up to several billion particles per generation, so there is great flexibility in this variable.
+
+- **-l [lookups]**
+Sets the number of cross-section (XS) lookups to perform per particle. By default, this value is set to 34, which represents the average number of XS lookups per particle over the course of its lifetime in a light water reactor problem. Users should only alter this value if they are trying to capture the behavior of a different type of reactor (e.g., one with a fast spectrum), where the number of lookups per history may be different.
+
+- **-h [hash bins]**
+Sets the number of hash bins (only relevant when using the hash lookup algorithm, as selected with "-G hash"). Default is 10,000.
+
+- **-b [binary mode]**
+This optional mode can read or write the simulation data structures to disk. Options are ("read" or "write"). This may be useful if it is necessary to minimize the initialization phase of the program, which has a non-trivial runtime. The generated file is named "XS_data.dat" and will be located in the current working directory. The same file name and location will be used when reading. Note that as the file is binary, it may not be portable between compilers and computer systems. NOTE: When running in the "read" mode, you must be running with an identical program configuration as when the file was generated. E.g., if the file was generated with the "-G nuclide" argument, subsequent runs reading from that file must use the same configuration flags.
+
+- **-k [kernel]**
+There are several optimized variants of the main kernel. All source bases run basically the same "baseline" kernel as default. Optimized kernels can be selected at runtime with this argument. Default is "0" for the baseline, other variants are numbered 1, 2, ... etc. People interested in implementing their own optimized variants are encouraged to use this interface for convenience rather than writing over the main kernel. The baseline kernel is defined at the top of the "Simulation.c" source file, with the other variants being defined towards the end of the file after a large comment block delineation. The optimized variants are related to different ways of sorting the sampled values such that there is less thread divergence and much better cache re-usage when executing the lookup kernel on contiguous sorted elements. More details can be found in the [Optimized Kernels](#Optimized-Kernels) section.
+
+## Feature Discussion
+
+### MPI Support
+
+While XSBench is primarily used to investigate "on node parallelism" issues, some systems provide power & performance statistics batched in multi-node configurations. To accommodate this, XSBench provides an MPI mode which runs the code on all MPI ranks simultaneously. There is no decomposition across ranks of any kind, and all ranks accomplish the same work. This is a "weak scaling" approach -- for instance, if running the event-based model all MPI ranks will execute 17,000,000 cross section lookups regardless of how many ranks are used. There is only one point of MPI communication (a reduce) at the end, which aggregates the timing statistics and averages them across MPI ranks before printing them out. MPI support can be enabled with the makefile flag "MPI". If you are not using the mpicc wrapper on your system, you may need to alter the makefile to make use of your desired compiler.
+
+### Verification Support
+
+Legacy versions of XSBench had a special "Verification" compiler flag option to enable verification of the results. However, a much more performant and portable verification scheme was developed and is now used for all configurations -- therefore, it is not necessary to compile with or without the verification mode as it is always enabled by default. XSBench generates a hash of the results at the end of the simulation and displays it with the other data once the code has completed executing. This hash can then be verified against hashes that other versions or configurations of the code generate. For instance, running XSBench with 4 threads vs 8 threads (on a machine that supports that configuration) should generate the same hash number. Running on GPU vs CPU should not change the hash number. However, changing the model / run parameters is expected to generate a totally different hash number (i.e., increasing the number of particles, number of gridpoints, etc, will result in different hashes). However, changing the type of lookup performed (e.g., nuclide, unionized, or hash) should result in the same hash being generated. Changing the simulation mode (history or event) will generate different hashes.
+
+### Binary File Support
+
+Instead of initializing the randomized synthetic cross section data structres in XSBench everytime it is run, you may optionally have XSBench generate a data set and write it to file. It can then be read on subsequent runs to speed up initialization. This process is controlled with the "-b (read, write)" command line argument. This feature may be extremely useful for users running on simulators where walltime minimization is critical for logistical purposes, or for users who are doing many sequential runs. Note that identical input parameters (problem size, solution method etc) must be used when reading and writing a binary file. No runtime checks are made to validate that the file correctly corresponds to the selected input parameters.
+
+
+## Algorithms
+
+### Transport Simulation Styles
+
+#### History-Based Transport
+
+The default simulation model used in XSBench is the "history-based" model. In this model, parallelism is expressed over independent particle histories, with each particle being simulated in a serial fashion from birth to death: 
+
+```c
+for each particle do		   // Independent
+	while particle is alive do // Dependent
+		Move particle to collision site
+		Process particle collision
+```
+
+This method of parallelism is very memory efficient, as the total number of particles that must be kept in memory at once is equivalent to the total number of active threads being run in the simulation. However, as there are many different types of collision events, the history-based model means that there is no natural SIMD style parallelism available for work happening between different threads.
+
+#### Event-Based Transport
+
+An alternative simulation model is the "event-based" model. In this model, parallelism is instead expressed over different collision (or "event") types. To facilitate this, all particles in the simulation are stored in memory at once. Each event kernel is executed in parallel on vectors of particles that currently require that event to be executed:
+
+```c
+Get vector of source particles
+while any particles are alive do	     // Dependent
+	for each living particle do          // Independent
+		Move particle to collision site
+	for each living particle do          // Independent
+		Process particle collision
+	Sort/consolidate surviving particles
+```
+This method of parallelism is requires more memory and requires an extra stream compaction kernel to sort and organize the particles periodically to ready them for the different event kernels. The benefit of this model is that kernels can potentially be execute in a SIMD manner and with higher cache efficiency due to the potential to sort particles by material and energy. On CPU architectures, the costs of sorting and buffering particles typically outweigh the benefits of the event-based model, but on accelerator architectures the tradeoff has been found to usually be more favorable.
+
+### Cross Section (XS) Lookup Methods
+
+XSBench represents the macroscopic cross section lookup kernel. This kernel is responsible for adding together microscopic cross section data from all nuclides present in the material the neutron is travelling through, given a certain energy:
+
+<p align="center"> <img src="docs/img/XS_equation.svg" alt="XS_Lookup_EQ" width="500"/> </p>
+
+Macroscopic cross section data is typically required for multiple reaction channels "c", such as the total cross section, fission cross section, etc. This data is typically stored in point-wise data form for each nuclide. There are multiple ways of accessesing this data in an efficient manner which will be discusses in this section.
+
+#### Nuclide Grid
+
+This is the default "naive" method of performing macroscopic XS lookups. XS data is stored for a number of energy levels for each nuclide in the simulation problem. Different nuclides can have a different number of energy levels. For instance, U-238 usually has over 100k energy levels, whereas some other nuclides may only have a few thousand. The "Nuclide Grid" is composed of all nuclides in the problem, with a variable number of data points for each nuclide. Each data point is composed of the energy level and accompanying cross section data for multiple different reaction channels:
+
+<p align="center"> <img src="docs/img/xs_point.png" alt="xs_point" width="300"/> </p>
+
+These XS data points are arranged into the nuclide grid:
+
+<p align="center"> <img src="docs/img/nuclide_grid.png" alt="nuclide_grid" width="350"/> </p>
+
+When assembling a macroscopic cross section data point, we will be accessing and interpolating data from the nuclide grid for a neutron travelling through a given material (composed of some number of nuclides) and at a given energy level. This will involve performing a binary search for each nuclide:
+
+```
+Nuclide_Grid_Search( Energy E, Material M ):
+	macroscopic XS = 0
+	for each nuclide in M do:
+		index = binary search to find E in nuclide grid
+		interpolate data from grid[nuclide, index]
+		macroscopic XS += data
+```
+
+This algorithm requires no extra memory usage beyond the minimum to represent the pointwise cross section data, but also requires that a binary search be run for each nuclide in the material the neutron is travelling through. In the case of depleted fuel, there can be 300+ nuclides, making this option computationally expensive.
+
+#### Unionized Energy Grid
+
+One way of speeding up the nuclide grid search is to form a separate acceleration structure to reduce the number of binary searches that need to be performed. In the Unionized Energy Grid (EUG) method, a second grid is created with columns corresponding to the **union** of all energy levels from the nuclide grid. For each energy level (column) in the unionized grid, each row stores an index corresponding to the closest location in the nuclide grid for each nuclide corresponding that energy level:
+
+<p align="center"> <img src="docs/img/UEG.png" alt="UEG" width="500"/> </p>
+
+A lookup using the UEG therefore requires only one single binary search on the unionized grid, allowing then for fast accesses using the indices stored at that energy level:
+
+```
+Unionized_Grid_Search( Energy E, Material M ):
+	macroscopic XS = 0
+	UEG_index = binary search to find E in unionized grid
+	for each nuclide in M do:
+		index = unionized_grid[nuclide, UEG_index]
+		interpolate data from grid[nuclide, index]
+		macroscopic XS += data
+```
+
+#### Logarithmic Hash Grid
+
+An alternative to the unionized energy grid is the logarithmic hash grid. This method takes in account the fact that while nuclides will be tabulated on grids containing different numbers of energy points, the points within each nuclide's grid will in general be spaced in (roughly) uniform maner in log space . Therefore, the nuclide grid is augmented with a separate acceleration structure similar to the unionized grid. However, the number of columns is capped at some number of bins spaced evenly in log space, with each row therefore corresponding to an approximate location within each nuclide's grid for that energy level. While the unionized grid points exactly to the correct index in the nuclide grid, the logarithmic hash grid points to only an approximate location below the true point -- meaning that a fast binary or iterative search must still be performed over the constrained area (typically only 10 or so elements in size):
+
+```
+Logarithmic_Hash_Grid_Search( Energy E, Material M ):
+	macroscopic XS = 0
+	hash_index = grid_delta * (ln(E) - grid_minimum_energy)
+	for each nuclide in M do:
+		i_low  = unionized_grid[nuclide, hash_index]
+		i_high = unionized_grid[nuclide, hash_index+1]
+		index = binary search in range(i_low, i_high) to find E in nuclide grid
+		interpolate data from grid[nuclide, index]
+		macroscopic XS += data
+```
+
+Compared to the unionized energy grid method, the logarithmic hash method uses far less memory but typically results in competitive performance. More details on this method can be found in the following publication:
+   
+>Forrest B Brown. New hash-based energy lookup algorithm for monte carlo codes. Trans. Am. Nucl. Soc., 111:659–662, 2014. http://permalink.lanl.gov/object/tr?what=info:lanl-repo/lareport/LA-UR-14-27037
+
+
+## Optimized Kernels
+
+If using the event-based model, we will be executing the lookup kernel in XSBench across all particles at once. While SIMD execution is possible using this method, typically issues can arrise that greatly reduce SIMD efficiency. In particular, different materials in the simulation have very different numbers of nuclides in them. For instance, spent fuel has 300+ nuclides, while moderator regions only have 10 or so nuclides. This creates a significant load imbalance across lanes in a SIMD vector, as some particles may only need a few iterations to complete all nuclides while others would need hundreds. Furthermore, due to the random memory accesses involved in the binary search process, efficient SIMD execution of the event-based model is not possible without some optimizations.
+
+One promising optimization for the event-based model is to perform a key-value sort of particles: first by material, and then by energy within each material. The first sort by material allows for adjacent particles in the vector to typically reside in the same type of material -- meaning that they will require the same number of nuclide lookup iterations. Then, the energy sort means that adjacent particles in the vector will be located close in energy space -- potentially allowing for many adjacent particles to access the same energy indices in each nuclide and therefore perform many or all of the same branching operations and read the same cache lines into memory at the same time. Once sorted, separate event kernels are then called for each material in the simulation. These two sorts can potentially boost both SIMD efficieny and cache efficiency, with effects being amplified as more particles are simulated at each event stage. The downside to this optimization is the introduction of the key-value particle sorting operations, which can be costly and potentially outweight any gains due to improved SIMD efficiency and cache performance.
+
+## Citing XSBench
+
+Papers citing the XSBench program in general should refer to:
+
+>J. R. Tramm, A. R. Siegel, T. Islam, and M. Schulz, “XSBench - The Development and Verification of a Performance Abstraction for Monte Carlo Reactor Analysis,” presented at PHYSOR 2014 - The Role of Reactor Physics toward a Sustainable Future, Kyoto. https://www.mcs.anl.gov/papers/P5064-0114.pdf
+
+Bibtex Entry:
+
+```bibtex
+@inproceedings{Tramm:wy,
+author = {Tramm, John R and Siegel, Andrew R and Islam, Tanzima and Schulz, Martin},
+title = {{XSBench} - The Development and Verification of a Performance Abstraction for {M}onte {C}arlo Reactor Analysis},
+booktitle = {{PHYSOR} 2014 - The Role of Reactor Physics toward a Sustainable Future},
+address = {Kyoto},
+year = 2014,
+url = "https://www.mcs.anl.gov/papers/P5064-0114.pdf"
+}
+```
+
+## Development Team
+Authored and maintained by John Tramm ([@jtramm](https://github.com/jtramm)) with help from Ron Rahaman, Amanda Lund, and other [contributors](https://github.com/ANL-CESAR/XSBench/graphs/contributors).

--- a/targets/XSBench/cuda/Simulation.cu
+++ b/targets/XSBench/cuda/Simulation.cu
@@ -1,0 +1,1119 @@
+#include "XSbench_header.cuh"
+
+////////////////////////////////////////////////////////////////////////////////////
+// BASELINE FUNCTIONS
+////////////////////////////////////////////////////////////////////////////////////
+// All "baseline" code is at the top of this file. The baseline code is a simple
+// port of the original CPU OpenMP code to CUDA with few significant changes or
+// optimizations made. Following these functions are a number of optimized variants,
+// which each deploy a different combination of optimizations strategies. By
+// default, XSBench will only run the baseline implementation. Optimized variants
+// must be specifically selected using the "-k <optimized variant ID>" command
+// line argument.
+////////////////////////////////////////////////////////////////////////////////////
+
+unsigned long long run_event_based_simulation_baseline(Inputs in, SimulationData SD, int mype, Profile* profile)
+{
+	double start = get_time();
+        // Move Data to GPU
+        SimulationData GSD = move_simulation_data_to_device(in, mype, SD);
+	profile->host_to_device_time = get_time() - start;
+
+        ////////////////////////////////////////////////////////////////////////////////
+        // Configure & Launch Simulation Kernel
+        ////////////////////////////////////////////////////////////////////////////////
+        if( mype == 0)	printf("Running baseline event-based simulation...\n");
+
+        int nthreads = 256;
+        int nblocks = ceil( (double) in.lookups / (double) nthreads);
+
+	int nwarmups = in.num_warmups;
+	start = 0.0;
+	for (int i = 0; i < in.num_iterations + nwarmups; i++) {
+		if (i == nwarmups) {
+			gpuErrchk( cudaDeviceSynchronize() );
+			start = get_time();
+		}
+		xs_lookup_kernel_baseline<<<nblocks, nthreads>>>( in, GSD );
+	}
+	gpuErrchk( cudaPeekAtLastError() );
+	gpuErrchk( cudaDeviceSynchronize() );
+	profile->kernel_time = get_time() - start;
+
+        ////////////////////////////////////////////////////////////////////////////////
+        // Reduce Verification Results
+        ////////////////////////////////////////////////////////////////////////////////
+
+        if( mype == 0)	printf("Reducing verification results...\n");
+	start = get_time();
+        gpuErrchk(cudaMemcpy(SD.verification, GSD.verification, in.lookups * sizeof(unsigned long), cudaMemcpyDeviceToHost) );
+	profile->device_to_host_time = get_time() - start;
+
+        unsigned long verification_scalar = 0;
+        for( int i =0; i < in.lookups; i++ )
+                verification_scalar += SD.verification[i];
+
+        release_device_memory(GSD);
+
+        return verification_scalar;
+}
+
+// In this kernel, we perform a single lookup with each thread. Threads within a warp
+// do not really have any relation to each other, and divergence due to high nuclide count fuel
+// material lookups are costly. This kernel constitutes baseline performance.
+__global__ void xs_lookup_kernel_baseline(Inputs in, SimulationData GSD )
+{
+        // The lookup ID. Used to set the seed, and to store the verification value
+        const int i = blockIdx.x *blockDim.x + threadIdx.x;
+
+        if( i >= in.lookups )
+                return;
+
+        // Set the initial seed value
+        uint64_t seed = STARTING_SEED;
+
+        // Forward seed to lookup index (we need 2 samples per lookup)
+        seed = fast_forward_LCG(seed, 2*i);
+
+        // Randomly pick an energy and material for the particle
+        double p_energy = LCG_random_double(&seed);
+        int mat         = pick_mat(&seed);
+
+        double macro_xs_vector[5] = {0};
+
+        // Perform macroscopic Cross Section Lookup
+        calculate_macro_xs(
+                p_energy,        // Sampled neutron energy (in lethargy)
+                mat,             // Sampled material type index neutron is in
+                in.n_isotopes,   // Total number of isotopes in simulation
+                in.n_gridpoints, // Number of gridpoints per isotope in simulation
+                GSD.num_nucs,     // 1-D array with number of nuclides per material
+                GSD.concs,        // Flattened 2-D array with concentration of each nuclide in each material
+                GSD.unionized_energy_array, // 1-D Unionized energy array
+                GSD.index_grid,   // Flattened 2-D grid holding indices into nuclide grid for each unionized energy level
+                GSD.nuclide_grid, // Flattened 2-D grid holding energy levels and XS_data for all nuclides in simulation
+                GSD.mats,         // Flattened 2-D array with nuclide indices defining composition of each type of material
+                macro_xs_vector, // 1-D array with result of the macroscopic cross section (5 different reaction channels)
+                in.grid_type,    // Lookup type (nuclide, hash, or unionized)
+                in.hash_bins,    // Number of hash bins used (if using hash lookup type)
+                GSD.max_num_nucs  // Maximum number of nuclides present in any material
+        );
+
+        // For verification, and to prevent the compiler from optimizing
+        // all work out, we interrogate the returned macro_xs_vector array
+        // to find its maximum value index, then increment the verification
+        // value by that index. In this implementation, we have each thread
+        // write to its thread_id index in an array, which we will reduce
+        // with a thrust reduction kernel after the main simulation kernel.
+        double max = -1.0;
+        int max_idx = 0;
+        for(int j = 0; j < 5; j++ )
+        {
+                if( macro_xs_vector[j] > max )
+                {
+                        max = macro_xs_vector[j];
+                        max_idx = j;
+                }
+        }
+        GSD.verification[i] = max_idx+1;
+}
+
+// Calculates the microscopic cross section for a given nuclide & energy
+__device__ void calculate_micro_xs(   double p_energy, int nuc, long n_isotopes,
+                                   long n_gridpoints,
+                                   double * __restrict__ egrid, int * __restrict__ index_data,
+                                   NuclideGridPoint * __restrict__ nuclide_grids,
+                                   long idx, double * __restrict__ xs_vector, int grid_type, int hash_bins ){
+        // Variables
+        double f;
+        NuclideGridPoint * low, * high;
+
+        // If using only the nuclide grid, we must perform a binary search
+        // to find the energy location in this particular nuclide's grid.
+        if( grid_type == NUCLIDE )
+        {
+                // Perform binary search on the Nuclide Grid to find the index
+                idx = grid_search_nuclide( n_gridpoints, p_energy, &nuclide_grids[nuc*n_gridpoints], 0, n_gridpoints-1);
+
+                // pull ptr from nuclide grid and check to ensure that
+                // we're not reading off the end of the nuclide's grid
+                if( idx == n_gridpoints - 1 )
+                        low = &nuclide_grids[nuc*n_gridpoints + idx - 1];
+                else
+                        low = &nuclide_grids[nuc*n_gridpoints + idx];
+        }
+        else if( grid_type == UNIONIZED) // Unionized Energy Grid - we already know the index, no binary search needed.
+        {
+                // pull ptr from energy grid and check to ensure that
+                // we're not reading off the end of the nuclide's grid
+                if( index_data[idx * n_isotopes + nuc] == n_gridpoints - 1 )
+                        low = &nuclide_grids[nuc*n_gridpoints + index_data[idx * n_isotopes + nuc] - 1];
+                else
+                        low = &nuclide_grids[nuc*n_gridpoints + index_data[idx * n_isotopes + nuc]];
+        }
+        else // Hash grid
+{
+                // load lower bounding index
+                int u_low = index_data[idx * n_isotopes + nuc];
+
+                // Determine higher bounding index
+                int u_high;
+                if( idx == hash_bins - 1 )
+                        u_high = n_gridpoints - 1;
+                else
+                        u_high = index_data[(idx+1)*n_isotopes + nuc] + 1;
+
+                // Check edge cases to make sure energy is actually between these
+                // Then, if things look good, search for gridpoint in the nuclide grid
+                // within the lower and higher limits we've calculated.
+                double e_low  = nuclide_grids[nuc*n_gridpoints + u_low].energy;
+                double e_high = nuclide_grids[nuc*n_gridpoints + u_high].energy;
+                int lower;
+                if( p_energy <= e_low )
+                        lower = 0;
+                else if( p_energy >= e_high )
+                        lower = n_gridpoints - 1;
+                else
+                        lower = grid_search_nuclide( n_gridpoints, p_energy, &nuclide_grids[nuc*n_gridpoints], u_low, u_high);
+
+                if( lower == n_gridpoints - 1 )
+                        low = &nuclide_grids[nuc*n_gridpoints + lower - 1];
+                else
+                        low = &nuclide_grids[nuc*n_gridpoints + lower];
+        }
+
+        high = low + 1;
+
+        // calculate the re-useable interpolation factor
+        f = (high->energy - p_energy) / (high->energy - low->energy);
+
+        // Total XS
+        xs_vector[0] = high->total_xs - f * (high->total_xs - low->total_xs);
+
+        // Elastic XS
+        xs_vector[1] = high->elastic_xs - f * (high->elastic_xs - low->elastic_xs);
+
+        // Absorbtion XS
+        xs_vector[2] = high->absorbtion_xs - f * (high->absorbtion_xs - low->absorbtion_xs);
+
+        // Fission XS
+        xs_vector[3] = high->fission_xs - f * (high->fission_xs - low->fission_xs);
+
+        // Nu Fission XS
+        xs_vector[4] = high->nu_fission_xs - f * (high->nu_fission_xs - low->nu_fission_xs);
+}
+
+// Calculates macroscopic cross section based on a given material & energy
+__device__ void calculate_macro_xs( double p_energy, int mat, long n_isotopes,
+                                   long n_gridpoints, int * __restrict__ num_nucs,
+                                   double * __restrict__ concs,
+                                   double * __restrict__ egrid, int * __restrict__ index_data,
+                                   NuclideGridPoint * __restrict__ nuclide_grids,
+                                   int * __restrict__ mats,
+                                   double * __restrict__ macro_xs_vector, int grid_type, int hash_bins, int max_num_nucs ){
+        int p_nuc; // the nuclide we are looking up
+        long idx = -1;
+        double conc; // the concentration of the nuclide in the material
+
+        // cleans out macro_xs_vector
+        for( int k = 0; k < 5; k++ )
+                macro_xs_vector[k] = 0;
+
+        // If we are using the unionized energy grid (UEG), we only
+        // need to perform 1 binary search per macroscopic lookup.
+        // If we are using the nuclide grid search, it will have to be
+        // done inside of the "calculate_micro_xs" function for each different
+        // nuclide in the material.
+        if( grid_type == UNIONIZED )
+                idx = grid_search( n_isotopes * n_gridpoints, p_energy, egrid);
+        else if( grid_type == HASH )
+        {
+        double du = 1.0 / hash_bins;
+        idx = p_energy / du;
+}
+
+        // Once we find the pointer array on the UEG, we can pull the data
+        // from the respective nuclide grids, as well as the nuclide
+        // concentration data for the material
+        // Each nuclide from the material needs to have its micro-XS array
+        // looked up & interpolatied (via calculate_micro_xs). Then, the
+        // micro XS is multiplied by the concentration of that nuclide
+        // in the material, and added to the total macro XS array.
+        // (Independent -- though if parallelizing, must use atomic operations
+        //  or otherwise control access to the xs_vector and macro_xs_vector to
+        //  avoid simulataneous writing to the same data structure)
+        for( int j = 0; j < num_nucs[mat]; j++ )
+        {
+                double xs_vector[5];
+                p_nuc = mats[mat*max_num_nucs + j];
+                conc = concs[mat*max_num_nucs + j];
+                calculate_micro_xs( p_energy, p_nuc, n_isotopes,
+                                   n_gridpoints, egrid, index_data,
+                                   nuclide_grids, idx, xs_vector, grid_type, hash_bins );
+                for( int k = 0; k < 5; k++ )
+                        macro_xs_vector[k] += xs_vector[k] * conc;
+        }
+}
+
+
+// binary search for energy on unionized energy grid
+// returns lower index
+__device__ long grid_search( long n, double quarry, double * __restrict__ A)
+{
+        long lowerLimit = 0;
+        long upperLimit = n-1;
+        long examinationPoint;
+        long length = upperLimit - lowerLimit;
+
+        while( length > 1 )
+        {
+                examinationPoint = lowerLimit + ( length / 2 );
+
+                if( A[examinationPoint] > quarry )
+                        upperLimit = examinationPoint;
+                else
+                        lowerLimit = examinationPoint;
+
+                length = upperLimit - lowerLimit;
+        }
+
+        return lowerLimit;
+}
+
+// binary search for energy on nuclide energy grid
+__host__ __device__ long grid_search_nuclide( long n, double quarry, NuclideGridPoint * A, long low, long high)
+{
+        long lowerLimit = low;
+        long upperLimit = high;
+        long examinationPoint;
+        long length = upperLimit - lowerLimit;
+
+        while( length > 1 )
+        {
+                examinationPoint = lowerLimit + ( length / 2 );
+
+                if( A[examinationPoint].energy > quarry )
+                        upperLimit = examinationPoint;
+                else
+                        lowerLimit = examinationPoint;
+
+                length = upperLimit - lowerLimit;
+        }
+
+        return lowerLimit;
+}
+
+// picks a material based on a probabilistic distribution
+__device__ int pick_mat( uint64_t * seed )
+{
+        // I have a nice spreadsheet supporting these numbers. They are
+        // the fractions (by volume) of material in the core. Not a
+        // *perfect* approximation of where XS lookups are going to occur,
+        // but this will do a good job of biasing the system nonetheless.
+
+        // Also could be argued that doing fractions by weight would be
+        // a better approximation, but volume does a good enough job for now.
+
+        double dist[12];
+        dist[0]  = 0.140;	// fuel
+        dist[1]  = 0.052;	// cladding
+        dist[2]  = 0.275;	// cold, borated water
+        dist[3]  = 0.134;	// hot, borated water
+        dist[4]  = 0.154;	// RPV
+        dist[5]  = 0.064;	// Lower, radial reflector
+        dist[6]  = 0.066;	// Upper reflector / top plate
+        dist[7]  = 0.055;	// bottom plate
+        dist[8]  = 0.008;	// bottom nozzle
+        dist[9]  = 0.015;	// top nozzle
+        dist[10] = 0.025;	// top of fuel assemblies
+        dist[11] = 0.013;	// bottom of fuel assemblies
+
+        double roll = LCG_random_double(seed);
+
+        // makes a pick based on the distro
+        for( int i = 0; i < 12; i++ )
+        {
+                double running = 0;
+                for( int j = i; j > 0; j-- )
+                        running += dist[j];
+                if( roll < running )
+                        return i;
+        }
+
+        return 0;
+}
+
+__host__ __device__ double LCG_random_double(uint64_t * seed)
+{
+        // LCG parameters
+        const uint64_t m = 9223372036854775808ULL; // 2^63
+        const uint64_t a = 2806196910506780709ULL;
+        const uint64_t c = 1ULL;
+        *seed = (a * (*seed) + c) % m;
+        return (double) (*seed) / (double) m;
+}
+
+__device__ uint64_t fast_forward_LCG(uint64_t seed, uint64_t n)
+{
+        // LCG parameters
+        const uint64_t m = 9223372036854775808ULL; // 2^63
+        uint64_t a = 2806196910506780709ULL;
+        uint64_t c = 1ULL;
+
+        n = n % m;
+
+        uint64_t a_new = 1;
+        uint64_t c_new = 0;
+
+        while(n > 0)
+        {
+                if(n & 1)
+                {
+                        a_new *= a;
+                        c_new = c_new * a + c;
+                }
+                c *= (a + 1);
+                a *= a;
+
+                n >>= 1;
+        }
+
+        return (a_new * seed + c_new) % m;
+}
+
+////////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////////
+// OPTIMIZED VARIANT FUNCTIONS
+////////////////////////////////////////////////////////////////////////////////////
+// This section contains a number of optimized variants of some of the above
+// functions, which each deploy a different combination of optimizations strategies
+// specific to GPU. By default, XSBench will not run any of these variants. They
+// must be specifically selected using the "-k <optimized variant ID>" command
+// line argument.
+////////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////////
+
+////////////////////////////////////////////////////////////////////////////////////
+// Optimization 1 -- Basic kernel splitting of sampling & lookup routines
+////////////////////////////////////////////////////////////////////////////////////
+// This optimization requires a little extra data to store all material IDs and
+// energies for the sampled particles between kernel calls. By itself, this
+// optimization is likely actually a bit of a slowdown compared to the baseline
+// kernel. However, it will be used by better optimization kernels down the line.
+////////////////////////////////////////////////////////////////////////////////////
+unsigned long long run_event_based_simulation_optimization_1(Inputs in, SimulationData GSD, int mype)
+{
+        const char * optimization_name = "Optimization 1 - basic sample/lookup kernel splitting";
+
+        if( mype == 0)	printf("Simulation Kernel:\"%s\"\n", optimization_name);
+
+        ////////////////////////////////////////////////////////////////////////////////
+        // Allocate Additional Data Structures Needed by Optimized Kernel
+        ////////////////////////////////////////////////////////////////////////////////
+        if( mype == 0)	printf("Allocating additional device data required by kernel...\n");
+        size_t sz;
+        size_t total_sz = 0;
+
+        sz = in.lookups * sizeof(double);
+        gpuErrchk( cudaMalloc((void **) &GSD.p_energy_samples, sz) );
+        total_sz += sz;
+        GSD.length_p_energy_samples = in.lookups;
+
+        sz = in.lookups * sizeof(int);
+        gpuErrchk( cudaMalloc((void **) &GSD.mat_samples, sz) );
+        total_sz += sz;
+        GSD.length_mat_samples = in.lookups;
+
+        if( mype == 0)	printf("Allocated an additional %.0lf MB of data on GPU.\n", total_sz/1024.0/1024.0);
+
+        ////////////////////////////////////////////////////////////////////////////////
+        // Configure & Launch Simulation Kernel
+        ////////////////////////////////////////////////////////////////////////////////
+        if( mype == 0)	printf("Beginning optimized simulation...\n");
+
+        int nthreads = 32;
+        int nblocks = ceil( (double) in.lookups / 32.0);
+
+        sampling_kernel<<<nblocks, nthreads>>>( in, GSD );
+        gpuErrchk( cudaPeekAtLastError() );
+        gpuErrchk( cudaDeviceSynchronize() );
+
+        xs_lookup_kernel_optimization_1<<<nblocks, nthreads>>>( in, GSD );
+        gpuErrchk( cudaPeekAtLastError() );
+        gpuErrchk( cudaDeviceSynchronize() );
+
+        ////////////////////////////////////////////////////////////////////////////////
+        // Reduce Verification Results
+        ////////////////////////////////////////////////////////////////////////////////
+        if( mype == 0)	printf("Reducing verification results...\n");
+
+        unsigned long verification_scalar = thrust::reduce(thrust::device, GSD.verification, GSD.verification + in.lookups, 0);
+        gpuErrchk( cudaPeekAtLastError() );
+        gpuErrchk( cudaDeviceSynchronize() );
+
+        return verification_scalar;
+}
+
+__global__ void sampling_kernel(Inputs in, SimulationData GSD )
+{
+        // The lookup ID.
+        const int i = blockIdx.x *blockDim.x + threadIdx.x;
+
+        if( i >= in.lookups )
+                return;
+
+        // Set the initial seed value
+        uint64_t seed = STARTING_SEED;
+
+        // Forward seed to lookup index (we need 2 samples per lookup)
+        seed = fast_forward_LCG(seed, 2*i);
+
+        // Randomly pick an energy and material for the particle
+        double p_energy = LCG_random_double(&seed);
+        int mat         = pick_mat(&seed);
+
+        // Store sample data in state array
+        GSD.p_energy_samples[i] = p_energy;
+        GSD.mat_samples[i] = mat;
+}
+
+__global__ void xs_lookup_kernel_optimization_1(Inputs in, SimulationData GSD )
+{
+        // The lookup ID. Used to set the seed, and to store the verification value
+        const int i = blockIdx.x *blockDim.x + threadIdx.x;
+
+        if( i >= in.lookups )
+                return;
+
+        double macro_xs_vector[5] = {0};
+
+        // Perform macroscopic Cross Section Lookup
+        calculate_macro_xs(
+                GSD.p_energy_samples[i],        // Sampled neutron energy (in lethargy)
+                GSD.mat_samples[i],             // Sampled material type index neutron is in
+                in.n_isotopes,   // Total number of isotopes in simulation
+                in.n_gridpoints, // Number of gridpoints per isotope in simulation
+                GSD.num_nucs,     // 1-D array with number of nuclides per material
+                GSD.concs,        // Flattened 2-D array with concentration of each nuclide in each material
+                GSD.unionized_energy_array, // 1-D Unionized energy array
+                GSD.index_grid,   // Flattened 2-D grid holding indices into nuclide grid for each unionized energy level
+                GSD.nuclide_grid, // Flattened 2-D grid holding energy levels and XS_data for all nuclides in simulation
+                GSD.mats,         // Flattened 2-D array with nuclide indices defining composition of each type of material
+                macro_xs_vector, // 1-D array with result of the macroscopic cross section (5 different reaction channels)
+                in.grid_type,    // Lookup type (nuclide, hash, or unionized)
+                in.hash_bins,    // Number of hash bins used (if using hash lookup type)
+                GSD.max_num_nucs  // Maximum number of nuclides present in any material
+        );
+
+        // For verification, and to prevent the compiler from optimizing
+        // all work out, we interrogate the returned macro_xs_vector array
+        // to find its maximum value index, then increment the verification
+        // value by that index. In this implementation, we have each thread
+        // write to its thread_id index in an array, which we will reduce
+        // with a thrust reduction kernel after the main simulation kernel.
+        double max = -1.0;
+        int max_idx = 0;
+        for(int j = 0; j < 5; j++ )
+        {
+                if( macro_xs_vector[j] > max )
+                {
+                        max = macro_xs_vector[j];
+                        max_idx = j;
+                }
+        }
+        GSD.verification[i] = max_idx+1;
+}
+
+////////////////////////////////////////////////////////////////////////////////////
+// Optimization 2 -- Kernel Splitting + Material-Specific Lookup Kernels
+////////////////////////////////////////////////////////////////////////////////////
+// This one builds on the first optimization. It uses multiple kernels, one
+// for each material type, to better balance the workload across threads within
+// a warp. This works because each material will have a different number of
+// isotopes, with some having a ton, meaning that SIMD efficiency can be rather
+// low by default. Better efficiency may be gained in further optimizations by
+// sorting the lookups first.
+////////////////////////////////////////////////////////////////////////////////////
+unsigned long long run_event_based_simulation_optimization_2(Inputs in, SimulationData GSD, int mype)
+{
+        const char * optimization_name = "Optimization 2 - Material Lookup Kernels";
+
+        if( mype == 0)	printf("Simulation Kernel:\"%s\"\n", optimization_name);
+
+        ////////////////////////////////////////////////////////////////////////////////
+        // Allocate Additional Data Structures Needed by Optimized Kernel
+        ////////////////////////////////////////////////////////////////////////////////
+        if( mype == 0)	printf("Allocating additional device data required by kernel...\n");
+        size_t sz;
+        size_t total_sz = 0;
+
+        sz = in.lookups * sizeof(double);
+        gpuErrchk( cudaMalloc((void **) &GSD.p_energy_samples, sz) );
+        total_sz += sz;
+        GSD.length_p_energy_samples = in.lookups;
+
+        sz = in.lookups * sizeof(int);
+        gpuErrchk( cudaMalloc((void **) &GSD.mat_samples, sz) );
+        total_sz += sz;
+        GSD.length_mat_samples = in.lookups;
+
+        if( mype == 0)	printf("Allocated an additional %.0lf MB of data on GPU.\n", total_sz/1024.0/1024.0);
+
+        ////////////////////////////////////////////////////////////////////////////////
+        // Configure & Launch Simulation Kernel
+        ////////////////////////////////////////////////////////////////////////////////
+        if( mype == 0)	printf("Beginning optimized simulation...\n");
+
+        int nthreads = 32;
+        int nblocks = ceil( (double) in.lookups / 32.0);
+
+        sampling_kernel<<<nblocks, nthreads>>>( in, GSD );
+        gpuErrchk( cudaPeekAtLastError() );
+        gpuErrchk( cudaDeviceSynchronize() );
+
+        // Launch all material kernels individually
+        for( int m = 0; m < 12; m++ )
+                xs_lookup_kernel_optimization_2<<<nblocks, nthreads>>>( in, GSD, m );
+        gpuErrchk( cudaPeekAtLastError() );
+        gpuErrchk( cudaDeviceSynchronize() );
+
+        ////////////////////////////////////////////////////////////////////////////////
+        // Reduce Verification Results
+        ////////////////////////////////////////////////////////////////////////////////
+        if( mype == 0)	printf("Reducing verification results...\n");
+
+        unsigned long verification_scalar = thrust::reduce(thrust::device, GSD.verification, GSD.verification + in.lookups, 0);
+        gpuErrchk( cudaPeekAtLastError() );
+        gpuErrchk( cudaDeviceSynchronize() );
+
+        return verification_scalar;
+}
+
+__global__ void xs_lookup_kernel_optimization_2(Inputs in, SimulationData GSD, int m )
+{
+        // The lookup ID. Used to set the seed, and to store the verification value
+        const int i = blockIdx.x *blockDim.x + threadIdx.x;
+
+        if( i >= in.lookups )
+                return;
+
+        // Check that our material type matches the kernel material
+        int mat = GSD.mat_samples[i];
+        if( mat != m )
+                return;
+
+        double macro_xs_vector[5] = {0};
+
+        // Perform macroscopic Cross Section Lookup
+        calculate_macro_xs(
+                GSD.p_energy_samples[i],        // Sampled neutron energy (in lethargy)
+                mat,             // Sampled material type index neutron is in
+                in.n_isotopes,   // Total number of isotopes in simulation
+                in.n_gridpoints, // Number of gridpoints per isotope in simulation
+                GSD.num_nucs,     // 1-D array with number of nuclides per material
+                GSD.concs,        // Flattened 2-D array with concentration of each nuclide in each material
+                GSD.unionized_energy_array, // 1-D Unionized energy array
+                GSD.index_grid,   // Flattened 2-D grid holding indices into nuclide grid for each unionized energy level
+                GSD.nuclide_grid, // Flattened 2-D grid holding energy levels and XS_data for all nuclides in simulation
+                GSD.mats,         // Flattened 2-D array with nuclide indices defining composition of each type of material
+                macro_xs_vector, // 1-D array with result of the macroscopic cross section (5 different reaction channels)
+                in.grid_type,    // Lookup type (nuclide, hash, or unionized)
+                in.hash_bins,    // Number of hash bins used (if using hash lookup type)
+                GSD.max_num_nucs  // Maximum number of nuclides present in any material
+        );
+
+        // For verification, and to prevent the compiler from optimizing
+        // all work out, we interrogate the returned macro_xs_vector array
+        // to find its maximum value index, then increment the verification
+        // value by that index. In this implementation, we have each thread
+        // write to its thread_id index in an array, which we will reduce
+        // with a thrust reduction kernel after the main simulation kernel.
+        double max = -1.0;
+        int max_idx = 0;
+        for(int j = 0; j < 5; j++ )
+        {
+                if( macro_xs_vector[j] > max )
+                {
+                        max = macro_xs_vector[j];
+                        max_idx = j;
+                }
+        }
+        GSD.verification[i] = max_idx+1;
+}
+
+
+////////////////////////////////////////////////////////////////////////////////////
+// Optimization 3 -- Kernel Splitting + Fuel or Not-Fuel Lookups
+////////////////////////////////////////////////////////////////////////////////////
+// This optimization alters Optimization 2. Instead of executing a kernel call for
+// ALL different material types, only two different calls are made. One for fuel,
+// and one for all the other materials. As the fuel material has by far the most
+// isotopes, it takes much longer than the rest.
+////////////////////////////////////////////////////////////////////////////////////
+unsigned long long run_event_based_simulation_optimization_3(Inputs in, SimulationData GSD, int mype)
+{
+        const char * optimization_name = "Optimization 3 - Fuel or Other Lookup Kernels";
+
+        if( mype == 0)	printf("Simulation Kernel:\"%s\"\n", optimization_name);
+
+        ////////////////////////////////////////////////////////////////////////////////
+        // Allocate Additional Data Structures Needed by Optimized Kernel
+        ////////////////////////////////////////////////////////////////////////////////
+        if( mype == 0)	printf("Allocating additional device data required by kernel...\n");
+        size_t sz;
+        size_t total_sz = 0;
+
+        sz = in.lookups * sizeof(double);
+        gpuErrchk( cudaMalloc((void **) &GSD.p_energy_samples, sz) );
+        total_sz += sz;
+        GSD.length_p_energy_samples = in.lookups;
+
+        sz = in.lookups * sizeof(int);
+        gpuErrchk( cudaMalloc((void **) &GSD.mat_samples, sz) );
+        total_sz += sz;
+        GSD.length_mat_samples = in.lookups;
+
+        if( mype == 0)	printf("Allocated an additional %.0lf MB of data on GPU.\n", total_sz/1024.0/1024.0);
+
+        ////////////////////////////////////////////////////////////////////////////////
+        // Configure & Launch Simulation Kernel
+        ////////////////////////////////////////////////////////////////////////////////
+        if( mype == 0)	printf("Beginning optimized simulation...\n");
+
+        int nthreads = 32;
+        int nblocks = ceil( (double) in.lookups / 32.0);
+
+        sampling_kernel<<<nblocks, nthreads>>>( in, GSD );
+        gpuErrchk( cudaPeekAtLastError() );
+        gpuErrchk( cudaDeviceSynchronize() );
+
+        // Launch all material kernels individually
+        xs_lookup_kernel_optimization_3<<<nblocks, nthreads>>>( in, GSD, 0 );
+        xs_lookup_kernel_optimization_3<<<nblocks, nthreads>>>( in, GSD, 1 );
+        gpuErrchk( cudaPeekAtLastError() );
+        gpuErrchk( cudaDeviceSynchronize() );
+
+        ////////////////////////////////////////////////////////////////////////////////
+        // Reduce Verification Results
+        ////////////////////////////////////////////////////////////////////////////////
+        if( mype == 0)	printf("Reducing verification results...\n");
+
+        unsigned long verification_scalar = thrust::reduce(thrust::device, GSD.verification, GSD.verification + in.lookups, 0);
+        gpuErrchk( cudaPeekAtLastError() );
+        gpuErrchk( cudaDeviceSynchronize() );
+
+        return verification_scalar;
+}
+
+__global__ void xs_lookup_kernel_optimization_3(Inputs in, SimulationData GSD, int is_fuel )
+{
+        // The lookup ID. Used to set the seed, and to store the verification value
+        const int i = blockIdx.x *blockDim.x + threadIdx.x;
+
+        if( i >= in.lookups )
+                return;
+
+        int mat = GSD.mat_samples[i];
+
+        // If this is the fuel kernel, AND this is a fuel lookup, then perform a lookup
+        // OR if this is not the fuel kernel, AND this is not a fuel lookup, then perform the lookup
+        if( ((is_fuel == 1) && (mat == 0)) || ((is_fuel == 0) && (mat != 0 ) ))
+        {
+                double macro_xs_vector[5] = {0};
+
+                // Perform macroscopic Cross Section Lookup
+                calculate_macro_xs(
+                        GSD.p_energy_samples[i],        // Sampled neutron energy (in lethargy)
+                        mat,             // Sampled material type index neutron is in
+                        in.n_isotopes,   // Total number of isotopes in simulation
+                        in.n_gridpoints, // Number of gridpoints per isotope in simulation
+                        GSD.num_nucs,     // 1-D array with number of nuclides per material
+                        GSD.concs,        // Flattened 2-D array with concentration of each nuclide in each material
+                        GSD.unionized_energy_array, // 1-D Unionized energy array
+                        GSD.index_grid,   // Flattened 2-D grid holding indices into nuclide grid for each unionized energy level
+                        GSD.nuclide_grid, // Flattened 2-D grid holding energy levels and XS_data for all nuclides in simulation
+                        GSD.mats,         // Flattened 2-D array with nuclide indices defining composition of each type of material
+                        macro_xs_vector, // 1-D array with result of the macroscopic cross section (5 different reaction channels)
+                        in.grid_type,    // Lookup type (nuclide, hash, or unionized)
+                        in.hash_bins,    // Number of hash bins used (if using hash lookup type)
+                        GSD.max_num_nucs  // Maximum number of nuclides present in any material
+                );
+
+                // For verification, and to prevent the compiler from optimizing
+                // all work out, we interrogate the returned macro_xs_vector array
+                // to find its maximum value index, then increment the verification
+                // value by that index. In this implementation, we have each thread
+                // write to its thread_id index in an array, which we will reduce
+                // with a thrust reduction kernel after the main simulation kernel.
+                double max = -1.0;
+                int max_idx = 0;
+                for(int j = 0; j < 5; j++ )
+                {
+                        if( macro_xs_vector[j] > max )
+                        {
+                                max = macro_xs_vector[j];
+                                max_idx = j;
+                        }
+                }
+                GSD.verification[i] = max_idx+1;
+        }
+}
+
+
+////////////////////////////////////////////////////////////////////////////////////
+// Optimization 4 -- Kernel Splitting + All Material Lookups + Full Sort
+////////////////////////////////////////////////////////////////////////////////////
+// This optimization builds on optimization 2, adding in a full sort before
+// hand so that the warps should be densely packed together. This should maximize
+// SIMD efficiency of the kernel, but may incur an added cost for the sort.
+////////////////////////////////////////////////////////////////////////////////////
+unsigned long long run_event_based_simulation_optimization_4(Inputs in, SimulationData GSD, int mype)
+{
+        const char * optimization_name = "Optimization 4 - All Material Lookup Kernels + Material Sort";
+
+        if( mype == 0)	printf("Simulation Kernel:\"%s\"\n", optimization_name);
+
+        ////////////////////////////////////////////////////////////////////////////////
+        // Allocate Additional Data Structures Needed by Optimized Kernel
+        ////////////////////////////////////////////////////////////////////////////////
+        if( mype == 0)	printf("Allocating additional device data required by kernel...\n");
+        size_t sz;
+        size_t total_sz = 0;
+
+        sz = in.lookups * sizeof(double);
+        gpuErrchk( cudaMalloc((void **) &GSD.p_energy_samples, sz) );
+        total_sz += sz;
+        GSD.length_p_energy_samples = in.lookups;
+
+        sz = in.lookups * sizeof(int);
+        gpuErrchk( cudaMalloc((void **) &GSD.mat_samples, sz) );
+        total_sz += sz;
+        GSD.length_mat_samples = in.lookups;
+
+        if( mype == 0)	printf("Allocated an additional %.0lf MB of data on GPU.\n", total_sz/1024.0/1024.0);
+
+        ////////////////////////////////////////////////////////////////////////////////
+        // Configure & Launch Simulation Kernel
+        ////////////////////////////////////////////////////////////////////////////////
+        if( mype == 0)	printf("Beginning optimized simulation...\n");
+
+        int nthreads = 32;
+        int nblocks = ceil( (double) in.lookups / 32.0);
+
+        sampling_kernel<<<nblocks, nthreads>>>( in, GSD );
+        gpuErrchk( cudaPeekAtLastError() );
+        gpuErrchk( cudaDeviceSynchronize() );
+
+        // Count the number of fuel material lookups that need to be performed (fuel id = 0)
+        int n_lookups_per_material[12];
+        for( int m = 0; m < 12; m++ )
+                n_lookups_per_material[m] = thrust::count(thrust::device, GSD.mat_samples, GSD.mat_samples + in.lookups, m);
+
+        // Sort materials
+        thrust::sort_by_key(thrust::device, GSD.mat_samples, GSD.mat_samples + in.lookups, GSD.p_energy_samples);
+
+        // Launch all material kernels individually
+        int offset = 0;
+        for( int m = 0; m < 12; m++ )
+        {
+                nthreads = 32;
+                nblocks = ceil((double) n_lookups_per_material[m] / (double) nthreads);
+                xs_lookup_kernel_optimization_4<<<nblocks, nthreads>>>( in, GSD, m, n_lookups_per_material[m], offset );
+                offset += n_lookups_per_material[m];
+        }
+        gpuErrchk( cudaPeekAtLastError() );
+        gpuErrchk( cudaDeviceSynchronize() );
+
+        ////////////////////////////////////////////////////////////////////////////////
+        // Reduce Verification Results
+        ////////////////////////////////////////////////////////////////////////////////
+        if( mype == 0)	printf("Reducing verification results...\n");
+
+        unsigned long verification_scalar = thrust::reduce(thrust::device, GSD.verification, GSD.verification + in.lookups, 0);
+        gpuErrchk( cudaPeekAtLastError() );
+        gpuErrchk( cudaDeviceSynchronize() );
+
+        return verification_scalar;
+}
+
+__global__ void xs_lookup_kernel_optimization_4(Inputs in, SimulationData GSD, int m, int n_lookups, int offset )
+{
+        // The lookup ID. Used to set the seed, and to store the verification value
+        int i = blockIdx.x *blockDim.x + threadIdx.x;
+
+        if( i >= n_lookups )
+                return;
+
+        i += offset;
+
+        // Check that our material type matches the kernel material
+        int mat = GSD.mat_samples[i];
+        if( mat != m )
+                return;
+
+        double macro_xs_vector[5] = {0};
+
+        // Perform macroscopic Cross Section Lookup
+        calculate_macro_xs(
+                GSD.p_energy_samples[i],        // Sampled neutron energy (in lethargy)
+                mat,             // Sampled material type index neutron is in
+                in.n_isotopes,   // Total number of isotopes in simulation
+                in.n_gridpoints, // Number of gridpoints per isotope in simulation
+                GSD.num_nucs,     // 1-D array with number of nuclides per material
+                GSD.concs,        // Flattened 2-D array with concentration of each nuclide in each material
+                GSD.unionized_energy_array, // 1-D Unionized energy array
+                GSD.index_grid,   // Flattened 2-D grid holding indices into nuclide grid for each unionized energy level
+                GSD.nuclide_grid, // Flattened 2-D grid holding energy levels and XS_data for all nuclides in simulation
+                GSD.mats,         // Flattened 2-D array with nuclide indices defining composition of each type of material
+                macro_xs_vector, // 1-D array with result of the macroscopic cross section (5 different reaction channels)
+                in.grid_type,    // Lookup type (nuclide, hash, or unionized)
+                in.hash_bins,    // Number of hash bins used (if using hash lookup type)
+                GSD.max_num_nucs  // Maximum number of nuclides present in any material
+        );
+
+        // For verification, and to prevent the compiler from optimizing
+        // all work out, we interrogate the returned macro_xs_vector array
+        // to find its maximum value index, then increment the verification
+        // value by that index. In this implementation, we have each thread
+        // write to its thread_id index in an array, which we will reduce
+        // with a thrust reduction kernel after the main simulation kernel.
+        double max = -1.0;
+        int max_idx = 0;
+        for(int j = 0; j < 5; j++ )
+        {
+                if( macro_xs_vector[j] > max )
+                {
+                        max = macro_xs_vector[j];
+                        max_idx = j;
+                }
+        }
+        GSD.verification[i] = max_idx+1;
+}
+
+////////////////////////////////////////////////////////////////////////////////////
+// Optimization 5 -- Kernel Splitting + Fuel/Other Lookups + Fuel/Other Partition
+////////////////////////////////////////////////////////////////////////////////////
+// This optimization is similar to optimization 4, but instead of sorting
+// fully by material, we just sort by fuel or not fuel. Similarly, instead of
+// launching kernels for all materials, similar to optimization 3 we only launch
+// kernels for the fuel and other mateirals.
+////////////////////////////////////////////////////////////////////////////////////
+
+// Comparator for partitioning stage
+struct is_mat_fuel{
+        __host__ __device__
+        bool operator()(const int & a)
+        {
+                return a == 0;
+        }
+};
+
+unsigned long long run_event_based_simulation_optimization_5(Inputs in, SimulationData GSD, int mype)
+{
+        const char * optimization_name = "Optimization 5 - Fuel/No Fuel Lookup Kernels + Fuel/No Fuel Sort";
+
+        if( mype == 0)	printf("Simulation Kernel:\"%s\"\n", optimization_name);
+
+        ////////////////////////////////////////////////////////////////////////////////
+        // Allocate Additional Data Structures Needed by Optimized Kernel
+        ////////////////////////////////////////////////////////////////////////////////
+        if( mype == 0)	printf("Allocating additional device data required by kernel...\n");
+        size_t sz;
+        size_t total_sz = 0;
+
+        sz = in.lookups * sizeof(double);
+        gpuErrchk( cudaMalloc((void **) &GSD.p_energy_samples, sz) );
+        total_sz += sz;
+        GSD.length_p_energy_samples = in.lookups;
+
+        sz = in.lookups * sizeof(int);
+        gpuErrchk( cudaMalloc((void **) &GSD.mat_samples, sz) );
+        total_sz += sz;
+        GSD.length_mat_samples = in.lookups;
+
+        if( mype == 0)	printf("Allocated an additional %.0lf MB of data on GPU.\n", total_sz/1024.0/1024.0);
+
+        ////////////////////////////////////////////////////////////////////////////////
+        // Configure & Launch Simulation Kernel
+        ////////////////////////////////////////////////////////////////////////////////
+        if( mype == 0)	printf("Beginning optimized simulation...\n");
+
+        int nthreads = 32;
+        int nblocks = ceil( (double) in.lookups / 32.0);
+
+        sampling_kernel<<<nblocks, nthreads>>>( in, GSD );
+        gpuErrchk( cudaPeekAtLastError() );
+        gpuErrchk( cudaDeviceSynchronize() );
+
+        // Count the number of fuel material lookups that need to be performed (fuel id = 0)
+        int n_fuel_lookups = thrust::count(thrust::device, GSD.mat_samples, GSD.mat_samples + in.lookups, 0);
+
+        // Partition fuel into the first part of the array
+        thrust::partition(thrust::device, GSD.mat_samples, GSD.mat_samples + in.lookups, GSD.p_energy_samples, is_mat_fuel());
+
+        // Launch all material kernels individually (asynchronous is allowed)
+        nblocks = ceil( (double) n_fuel_lookups / (double) nthreads);
+        xs_lookup_kernel_optimization_5<<<nblocks, nthreads>>>( in, GSD, n_fuel_lookups, 0 );
+
+        nblocks = ceil( (double) (in.lookups - n_fuel_lookups) / (double) nthreads);
+        xs_lookup_kernel_optimization_5<<<nblocks, nthreads>>>( in, GSD, in.lookups-n_fuel_lookups, n_fuel_lookups );
+
+        gpuErrchk( cudaPeekAtLastError() );
+        gpuErrchk( cudaDeviceSynchronize() );
+
+        ////////////////////////////////////////////////////////////////////////////////
+        // Reduce Verification Results
+        ////////////////////////////////////////////////////////////////////////////////
+        if( mype == 0)	printf("Reducing verification results...\n");
+
+        unsigned long verification_scalar = thrust::reduce(thrust::device, GSD.verification, GSD.verification + in.lookups, 0);
+        gpuErrchk( cudaPeekAtLastError() );
+        gpuErrchk( cudaDeviceSynchronize() );
+
+        return verification_scalar;
+}
+
+__global__ void xs_lookup_kernel_optimization_5(Inputs in, SimulationData GSD, int n_lookups, int offset )
+{
+        // The lookup ID. Used to set the seed, and to store the verification value
+        int i = blockIdx.x *blockDim.x + threadIdx.x;
+
+        if( i >= n_lookups )
+                return;
+
+        i += offset;
+
+        double macro_xs_vector[5] = {0};
+
+        // Perform macroscopic Cross Section Lookup
+        calculate_macro_xs(
+                GSD.p_energy_samples[i],        // Sampled neutron energy (in lethargy)
+                GSD.mat_samples[i],             // Sampled material type index neutron is in
+                in.n_isotopes,   // Total number of isotopes in simulation
+                in.n_gridpoints, // Number of gridpoints per isotope in simulation
+                GSD.num_nucs,     // 1-D array with number of nuclides per material
+                GSD.concs,        // Flattened 2-D array with concentration of each nuclide in each material
+                GSD.unionized_energy_array, // 1-D Unionized energy array
+                GSD.index_grid,   // Flattened 2-D grid holding indices into nuclide grid for each unionized energy level
+                GSD.nuclide_grid, // Flattened 2-D grid holding energy levels and XS_data for all nuclides in simulation
+                GSD.mats,         // Flattened 2-D array with nuclide indices defining composition of each type of material
+                macro_xs_vector, // 1-D array with result of the macroscopic cross section (5 different reaction channels)
+                in.grid_type,    // Lookup type (nuclide, hash, or unionized)
+                in.hash_bins,    // Number of hash bins used (if using hash lookup type)
+                GSD.max_num_nucs  // Maximum number of nuclides present in any material
+        );
+
+        // For verification, and to prevent the compiler from optimizing
+        // all work out, we interrogate the returned macro_xs_vector array
+        // to find its maximum value index, then increment the verification
+        // value by that index. In this implementation, we have each thread
+        // write to its thread_id index in an array, which we will reduce
+        // with a thrust reduction kernel after the main simulation kernel.
+        double max = -1.0;
+        int max_idx = 0;
+        for(int j = 0; j < 5; j++ )
+        {
+                if( macro_xs_vector[j] > max )
+                {
+                        max = macro_xs_vector[j];
+                        max_idx = j;
+                }
+        }
+        GSD.verification[i] = max_idx+1;
+}
+
+////////////////////////////////////////////////////////////////////////////////////
+// Optimization 6 -- Kernel Splitting + All Material Lookups + Full Sort
+//                   + Energy Sort
+////////////////////////////////////////////////////////////////////////////////////
+// This optimization builds on optimization 4, adding in a second sort by energy.
+// It is extremely fast, as now most of the threads within a warp will be hitting
+// the same indices in the lookup grids. This greatly reduces thread divergence and
+// greatly improves cache efficiency and re-use.
+//
+// However, it is unlikely that this exact optimization would be possible in a real
+// application like OpenMC. One major difference is that particle objects are quite
+// large, often having 50+ variable fields, such that sorting them in memory becomes
+// rather expensive. Instead, the best possible option would probably be to create
+// intermediate indexing (per Hamilton et. al 2019), and run the kernels indirectly.
+////////////////////////////////////////////////////////////////////////////////////
+unsigned long long run_event_based_simulation_optimization_6(Inputs in, SimulationData GSD, int mype)
+{
+        const char * optimization_name = "Optimization 6 - Material & Energy Sorts + Material-specific Kernels";
+
+        if( mype == 0)	printf("Simulation Kernel:\"%s\"\n", optimization_name);
+
+        ////////////////////////////////////////////////////////////////////////////////
+        // Allocate Additional Data Structures Needed by Optimized Kernel
+        ////////////////////////////////////////////////////////////////////////////////
+        if( mype == 0)	printf("Allocating additional device data required by kernel...\n");
+        size_t sz;
+        size_t total_sz = 0;
+
+        sz = in.lookups * sizeof(double);
+        gpuErrchk( cudaMalloc((void **) &GSD.p_energy_samples, sz) );
+        total_sz += sz;
+        GSD.length_p_energy_samples = in.lookups;
+
+        sz = in.lookups * sizeof(int);
+        gpuErrchk( cudaMalloc((void **) &GSD.mat_samples, sz) );
+        total_sz += sz;
+        GSD.length_mat_samples = in.lookups;
+
+        if( mype == 0)	printf("Allocated an additional %.0lf MB of data on GPU.\n", total_sz/1024.0/1024.0);
+
+        ////////////////////////////////////////////////////////////////////////////////
+        // Configure & Launch Simulation Kernel
+        ////////////////////////////////////////////////////////////////////////////////
+        if( mype == 0)	printf("Beginning optimized simulation...\n");
+
+        int nthreads = 32;
+        int nblocks = ceil( (double) in.lookups / 32.0);
+
+        sampling_kernel<<<nblocks, nthreads>>>( in, GSD );
+        gpuErrchk( cudaPeekAtLastError() );
+        gpuErrchk( cudaDeviceSynchronize() );
+
+        // Count the number of fuel material lookups that need to be performed (fuel id = 0)
+        int n_lookups_per_material[12];
+        for( int m = 0; m < 12; m++ )
+                n_lookups_per_material[m] = thrust::count(thrust::device, GSD.mat_samples, GSD.mat_samples + in.lookups, m);
+
+        // Sort by material first
+        thrust::sort_by_key(thrust::device, GSD.mat_samples, GSD.mat_samples + in.lookups, GSD.p_energy_samples);
+
+        // Now, sort each material by energy
+        int offset = 0;
+        for( int m = 0; m < 12; m++ )
+        {
+                thrust::sort_by_key(thrust::device, GSD.p_energy_samples + offset, GSD.p_energy_samples + offset + n_lookups_per_material[m], GSD.mat_samples + offset);
+                offset += n_lookups_per_material[m];
+        }
+
+        // Launch all material kernels individually
+        offset = 0;
+        for( int m = 0; m < 12; m++ )
+        {
+                nthreads = 32;
+                nblocks = ceil((double) n_lookups_per_material[m] / (double) nthreads);
+                xs_lookup_kernel_optimization_4<<<nblocks, nthreads>>>( in, GSD, m, n_lookups_per_material[m], offset );
+                offset += n_lookups_per_material[m];
+        }
+        gpuErrchk( cudaPeekAtLastError() );
+        gpuErrchk( cudaDeviceSynchronize() );
+
+        ////////////////////////////////////////////////////////////////////////////////
+        // Reduce Verification Results
+        ////////////////////////////////////////////////////////////////////////////////
+        if( mype == 0)	printf("Reducing verification results...\n");
+
+        unsigned long verification_scalar = thrust::reduce(thrust::device, GSD.verification, GSD.verification + in.lookups, 0);
+        gpuErrchk( cudaPeekAtLastError() );
+        gpuErrchk( cudaDeviceSynchronize() );
+
+        return verification_scalar;
+}

--- a/targets/XSBench/cuda/XSbench_header.cuh
+++ b/targets/XSBench/cuda/XSbench_header.cuh
@@ -1,0 +1,142 @@
+#ifndef __XSBENCH_HEADER_H__
+#define __XSBENCH_HEADER_H__
+
+#include<stdio.h>
+#include<stdlib.h>
+#include<math.h>
+#include<assert.h>
+#include<cuda.h>
+#include <thrust/reduce.h>
+#include <thrust/partition.h>
+#include<stdint.h>
+#include <chrono>
+#include "../XSbench_shared_header.h"
+
+// Grid types
+#define UNIONIZED 0
+#define NUCLIDE 1
+#define HASH 2
+
+// Simulation types
+#define HISTORY_BASED 1
+#define EVENT_BASED 2
+
+// Binary Mode Type
+#define NONE 0
+#define READ 1
+#define WRITE 2
+
+// Starting Seed
+#define STARTING_SEED 1070
+
+#define gpuErrchk(ans) { gpuAssert((ans), __FILE__, __LINE__); }
+inline void gpuAssert(cudaError_t code, const char *file, int line, bool abort=true)
+{
+        if (code != cudaSuccess)
+        {
+                fprintf(stderr,"GPUassert: %s %s %d\n", cudaGetErrorString(code), file, line);
+                if (abort) exit(code);
+        }
+}
+
+// Structures
+typedef struct{
+        double energy;
+        double total_xs;
+        double elastic_xs;
+        double absorbtion_xs;
+        double fission_xs;
+        double nu_fission_xs;
+} NuclideGridPoint;
+
+typedef struct{
+        int * num_nucs;                     // Length = length_num_nucs;
+        double * concs;                     // Length = length_concs
+        int * mats;                         // Length = length_mats
+        double * unionized_energy_array;    // Length = length_unionized_energy_array
+        int * index_grid;                   // Length = length_index_grid
+        NuclideGridPoint * nuclide_grid;    // Length = length_nuclide_grid
+        int length_num_nucs;
+        int length_concs;
+        int length_mats;
+        int length_unionized_energy_array;
+        long length_index_grid;
+        int length_nuclide_grid;
+        int max_num_nucs;
+        unsigned long * verification;
+        int length_verification;
+        double * p_energy_samples;
+        int length_p_energy_samples;
+        int * mat_samples;
+        int length_mat_samples;
+} SimulationData;
+
+// io.cu
+void logo(int version);
+void center_print(const char *s, int width);
+void border_print(void);
+void fancy_int(long a);
+Inputs read_CLI( int argc, char * argv[] );
+void print_CLI_error(void);
+void print_inputs(Inputs in, int nprocs, int version);
+int print_results( Inputs in, int mype, double runtime, int nprocs, unsigned long long vhash );
+void binary_write( Inputs in, SimulationData SD );
+SimulationData binary_read( Inputs in );
+
+// Simulation.cu
+unsigned long long run_event_based_simulation_baseline(Inputs in, SimulationData SD, int mype, Profile* profile);
+__global__ void xs_lookup_kernel_baseline(Inputs in, SimulationData GSD );
+__device__ void calculate_micro_xs(   double p_energy, int nuc, long n_isotopes,
+                                   long n_gridpoints,
+                                   double * __restrict__ egrid, int * __restrict__ index_data,
+                                   NuclideGridPoint * __restrict__ nuclide_grids,
+                                   long idx, double * __restrict__ xs_vector, int grid_type, int hash_bins );
+__device__ void calculate_macro_xs( double p_energy, int mat, long n_isotopes,
+                                   long n_gridpoints, int * __restrict__ num_nucs,
+                                   double * __restrict__ concs,
+                                   double * __restrict__ egrid, int * __restrict__ index_data,
+                                   NuclideGridPoint * __restrict__ nuclide_grids,
+                                   int * __restrict__ mats,
+                                   double * __restrict__ macro_xs_vector, int grid_type, int hash_bins, int max_num_nucs );
+__device__ long grid_search( long n, double quarry, double * __restrict__ A);
+__host__ __device__ long grid_search_nuclide( long n, double quarry, NuclideGridPoint * A, long low, long high);
+__device__ int pick_mat( uint64_t * seed );
+__host__ __device__ double LCG_random_double(uint64_t * seed);
+__device__ uint64_t fast_forward_LCG(uint64_t seed, uint64_t n);
+
+unsigned long long run_event_based_simulation_optimization_1(Inputs in, SimulationData GSD, int mype);
+__global__ void sampling_kernel(Inputs in, SimulationData GSD );
+__global__ void xs_lookup_kernel_optimization_1(Inputs in, SimulationData GSD );
+
+unsigned long long run_event_based_simulation_optimization_2(Inputs in, SimulationData GSD, int mype);
+__global__ void xs_lookup_kernel_optimization_2(Inputs in, SimulationData GSD, int m );
+
+unsigned long long run_event_based_simulation_optimization_3(Inputs in, SimulationData GSD, int mype);
+__global__ void xs_lookup_kernel_optimization_3(Inputs in, SimulationData GSD, int m );
+
+unsigned long long run_event_based_simulation_optimization_4(Inputs in, SimulationData GSD, int mype);
+__global__ void xs_lookup_kernel_optimization_4(Inputs in, SimulationData GSD, int m, int n_lookups, int offset );
+
+unsigned long long run_event_based_simulation_optimization_5(Inputs in, SimulationData GSD, int mype);
+__global__ void xs_lookup_kernel_optimization_5(Inputs in, SimulationData GSD, int n_lookups, int offset );
+
+unsigned long long run_event_based_simulation_optimization_6(Inputs in, SimulationData GSD, int mype);
+
+// GridInit.cu
+SimulationData grid_init_do_not_profile( Inputs in, int mype );
+SimulationData move_simulation_data_to_device( Inputs in, int mype, SimulationData SD );
+void release_device_memory(SimulationData GSD);
+void release_memory(SimulationData SD);
+
+// XSutils.cu
+int NGP_compare( const void * a, const void * b );
+int double_compare(const void * a, const void * b);
+double rn_v(void);
+size_t estimate_mem_usage( Inputs in );
+double get_time(void);
+
+// Materials.cu
+int * load_num_nucs(long n_isotopes);
+int * load_mats( int * num_nucs, long n_isotopes, int * max_num_nucs );
+double * load_concs( int * num_nucs, int max_num_nucs );
+#endif

--- a/targets/XSBench/cuda/XSutils.cu
+++ b/targets/XSBench/cuda/XSutils.cu
@@ -1,0 +1,91 @@
+#include "XSbench_header.cuh"
+
+int double_compare(const void * a, const void * b)
+{
+	double A = *((double *) a);
+	double B = *((double *) b);
+
+	if( A > B )
+		return 1;
+	else if( A < B )
+		return -1;
+	else
+		return 0;
+}
+
+int NGP_compare(const void * a, const void * b)
+{
+	NuclideGridPoint A = *((NuclideGridPoint *) a);
+	NuclideGridPoint B = *((NuclideGridPoint *) b);
+
+	if( A.energy > B.energy )
+		return 1;
+	else if( A.energy < B.energy )
+		return -1;
+	else
+		return 0;
+}
+
+
+// RNG Used for Verification Option.
+// This one has a static seed (must be set manually in source).
+// Park & Miller Multiplicative Conguential Algorithm
+// From "Numerical Recipes" Second Edition
+double rn_v(void)
+{
+	static unsigned long seed = 1337;
+	double ret;
+	unsigned long n1;
+	unsigned long a = 16807;
+	unsigned long m = 2147483647;
+	n1 = ( a * (seed) ) % m;
+	seed = n1;
+	ret = (double) n1 / m;
+	return ret;
+}
+
+
+size_t estimate_mem_usage( Inputs in )
+{
+	size_t single_nuclide_grid = in.n_gridpoints * sizeof( NuclideGridPoint );
+	size_t all_nuclide_grids   = in.n_isotopes * single_nuclide_grid;
+	size_t size_UEG		   = in.n_isotopes*in.n_gridpoints*sizeof(double) + in.n_isotopes*in.n_gridpoints*in.n_isotopes*sizeof(int);
+	size_t size_hash_grid	   = in.hash_bins * in.n_isotopes * sizeof(int);
+	size_t memtotal;
+
+	if( in.grid_type == UNIONIZED )
+		memtotal	  = all_nuclide_grids + size_UEG;
+	else if( in.grid_type == NUCLIDE )
+		memtotal	  = all_nuclide_grids;
+	else
+		memtotal	  = all_nuclide_grids + size_hash_grid;
+
+	memtotal	  = ceil(memtotal / (1024.0*1024.0));
+	return memtotal;
+}
+
+double get_time(void)
+{
+	#ifdef MPI
+	return MPI_Wtime();
+	#endif
+
+	#ifdef OPENMP
+	return omp_get_wtime();
+	#endif
+
+	#ifdef __cplusplus
+	// If using C++, we can do this:
+	unsigned long us_since_epoch = std::chrono::high_resolution_clock::now().time_since_epoch() / std::chrono::microseconds(1);
+	return (double) us_since_epoch / 1.0e6;
+	#else
+	struct timeval timecheck;
+
+	gettimeofday(&timecheck, NULL);
+	long ms = (long)timecheck.tv_sec * 1000 + (long)timecheck.tv_usec / 1000;
+
+	double time = (double) ms / 1000.0;
+
+	return time;
+	#endif
+}

--- a/targets/XSBench/cuda/io.cu
+++ b/targets/XSBench/cuda/io.cu
@@ -1,0 +1,540 @@
+#include "XSbench_header.cuh"
+
+// Prints program logo
+void logo(int version)
+{
+	border_print();
+	printf(
+	"                   __   __ ___________                 _                        \n"
+	"                   \\ \\ / //  ___| ___ \\               | |                       \n"
+	"                    \\ V / \\ `--.| |_/ / ___ _ __   ___| |__                     \n"
+	"                    /   \\  `--. \\ ___ \\/ _ \\ '_ \\ / __| '_ \\                    \n"
+	"                   / /^\\ \\/\\__/ / |_/ /  __/ | | | (__| | | |                   \n"
+	"                   \\/   \\/\\____/\\____/ \\___|_| |_|\\___|_| |_|                   \n\n"
+	       );
+	border_print();
+	center_print("Developed at Argonne National Laboratory", 79);
+	char v[100];
+	sprintf(v, "Version: %d", version);
+	center_print(v, 79);
+	border_print();
+}
+
+// Prints Section titles in center of 80 char terminal
+void center_print(const char *s, int width)
+{
+	int length = strlen(s);
+	int i;
+	for (i=0; i<=(width-length)/2; i++) {
+		fputs(" ", stdout);
+	}
+	fputs(s, stdout);
+	fputs("\n", stdout);
+}
+
+int print_results( Inputs in, int mype, double runtime, int nprocs,
+		   unsigned long long vhash )
+{
+	// Calculate Lookups per sec
+	int lookups = 0;
+	if( in.simulation_method == HISTORY_BASED )
+		lookups = in.lookups * in.particles;
+	else if( in.simulation_method == EVENT_BASED )
+		lookups = in.lookups;
+	int lookups_per_sec = (int) ((double) lookups / runtime);
+
+	// If running in MPI, reduce timing statistics and calculate average
+	#ifdef MPI
+	int total_lookups = 0;
+	MPI_Barrier(MPI_COMM_WORLD);
+	MPI_Reduce(&lookups_per_sec, &total_lookups, 1, MPI_INT,
+		   MPI_SUM, 0, MPI_COMM_WORLD);
+	#endif
+
+	int is_invalid_result = 1;
+
+	// Print output
+	if( mype == 0 )
+	{
+		border_print();
+		center_print("RESULTS", 79);
+		border_print();
+
+		// Print the results
+		printf("NOTE: Timings are estimated -- use nvprof/nsys/iprof/rocprof for formal analysis\n");
+		#ifdef MPI
+		printf("MPI ranks:   %d\n", nprocs);
+		#endif
+		#ifdef MPI
+		printf("Total Lookups/s:            ");
+		fancy_int(total_lookups);
+		printf("Avg Lookups/s per MPI rank: ");
+		fancy_int(total_lookups / nprocs);
+		#else
+		printf("Runtime:     %.3lf seconds\n", runtime);
+		printf("Lookups:     "); fancy_int(lookups);
+		printf("Lookups/s:   ");
+		fancy_int(lookups_per_sec);
+		#endif
+	}
+
+	unsigned long long large = 0;
+	unsigned long long small = 0;
+	if( in.simulation_method == EVENT_BASED )
+	{
+		small = 945990;
+		large = 952131;
+	}
+	else if( in.simulation_method == HISTORY_BASED )
+	{
+		small = 941535;
+		large = 954318;
+	}
+	if( strcmp(in.HM, "large") == 0 )
+	{
+		if( vhash == large )
+			is_invalid_result = 0;
+	}
+	else if( strcmp(in.HM, "small") == 0 )
+	{
+		if( vhash == small )
+			is_invalid_result = 0;
+	}
+
+	if(mype == 0 )
+	{
+		if( is_invalid_result )
+			printf("Verification checksum: %llu (WARNING - INAVALID CHECKSUM!)\n", vhash);
+		else
+			printf("Verification checksum: %llu (Valid)\n", vhash);
+		border_print();
+	}
+
+	return is_invalid_result;
+}
+
+void print_inputs(Inputs in, int nprocs, int version )
+{
+	// Calculate Estimate of Memory Usage
+	int mem_tot = estimate_mem_usage( in );
+	logo(version);
+	center_print("INPUT SUMMARY", 79);
+	border_print();
+	printf("Programming Model:            CUDA\n");
+	cudaDeviceProp prop;
+	int device;
+	cudaGetDevice(&device);
+	cudaGetDeviceProperties ( &prop, device );
+		printf("CUDA Device:                  %s\n", prop.name);
+	if( in.simulation_method == EVENT_BASED )
+		printf("Simulation Method:            Event Based\n");
+	else
+		printf("Simulation Method:            History Based\n");
+	if( in.grid_type == NUCLIDE )
+		printf("Grid Type:                    Nuclide Grid\n");
+	else if( in.grid_type == UNIONIZED )
+		printf("Grid Type:                    Unionized Grid\n");
+	else
+		printf("Grid Type:                    Hash\n");
+
+	printf("Materials:                    %d\n", 12);
+	printf("H-M Benchmark Size:           %s\n", in.HM);
+	printf("Total Nuclides:               %ld\n", in.n_isotopes);
+	printf("Gridpoints (per Nuclide):     ");
+	fancy_int(in.n_gridpoints);
+	if( in.grid_type == HASH )
+	{
+		printf("Hash Bins:                    ");
+		fancy_int(in.hash_bins);
+	}
+	if( in.grid_type == UNIONIZED )
+	{
+		printf("Unionized Energy Gridpoints:  ");
+		fancy_int(in.n_isotopes*in.n_gridpoints);
+	}
+	if( in.simulation_method == HISTORY_BASED )
+	{
+		printf("Particle Histories:           "); fancy_int(in.particles);
+		printf("XS Lookups per Particle:      "); fancy_int(in.lookups);
+	}
+	printf("Total XS Lookups:             "); fancy_int(in.lookups);
+	printf("Total XS Iterations:          "); fancy_int(in.num_iterations);
+	#ifdef MPI
+	printf("MPI Ranks:                    %d\n", nprocs);
+	printf("Mem Usage per MPI Rank (MB):  "); fancy_int(mem_tot);
+	#else
+	printf("Est. Memory Usage (MB):       "); fancy_int(mem_tot);
+	#endif
+	printf("Binary File Mode:             ");
+	if( in.binary_mode == NONE )
+		printf("Off\n");
+	else if( in.binary_mode == READ)
+		printf("Read\n");
+	else
+		printf("Write\n");
+	border_print();
+	center_print("INITIALIZATION - DO NOT PROFILE", 79);
+	border_print();
+}
+
+void border_print(void)
+{
+	printf(
+	"==================================================================="
+	"=============\n");
+}
+
+// Prints comma separated integers - for ease of reading
+void fancy_int( long a )
+{
+	if( a < 1000 )
+		printf("%ld\n",a);
+
+	else if( a >= 1000 && a < 1000000 )
+		printf("%ld,%03ld\n", a / 1000, a % 1000);
+
+	else if( a >= 1000000 && a < 1000000000 )
+		printf("%ld,%03ld,%03ld\n",a / 1000000,(a % 1000000) / 1000,a % 1000 );
+
+	else if( a >= 1000000000 )
+		printf("%ld,%03ld,%03ld,%03ld\n",
+		       a / 1000000000,
+		       (a % 1000000000) / 1000000,
+		       (a % 1000000) / 1000,
+		       a % 1000 );
+	else
+		printf("%ld\n",a);
+}
+
+void print_CLI_error(void)
+{
+	printf("Usage: ./XSBench <options>\n");
+	printf("Options include:\n");
+	printf("  -m <simulation method>   Simulation method (history, event)\n");
+	printf("  -s <size>                Size of H-M Benchmark to run (small, large, XL, XXL)\n");
+	printf("  -g <gridpoints>          Number of gridpoints per nuclide (overrides -s defaults)\n");
+	printf("  -G <grid type>           Grid search type (unionized, nuclide, hash). Defaults to unionized.\n");
+	printf("  -p <particles>           Number of particle histories\n");
+	printf("  -l <lookups>             History Based: Number of Cross-section (XS) lookups per particle. Event Based: Total number of XS lookups.\n");
+	printf("  -h <hash bins>           Number of hash bins (only relevant when used with \"-G hash\")\n");
+	printf("  -b <binary mode>         Read or write all data structures to file. If reading, this will skip initialization phase. (read, write)\n");
+	printf("  -k <kernel ID>           Specifies which kernel to run. 0 is baseline, 1, 2, etc are optimized variants. (0 is default.)\n");
+	printf("  -n <num iterations>      Specifies how many kernel iterations to run. (1 is default.)\n");
+	printf("  -w <num warmups>         Specifies how many warmup iterations to run. (0 is default.)\n");
+	printf("  --csv <file path>        Save output to csv file. (Default is stdout)\n");
+	printf("Default is equivalent to: -m history -s large -l 34 -p 500000 -G unionized -k 0 -n 1\n");
+	printf("See readme for full description of default run values\n");
+	exit(4);
+}
+
+Inputs read_CLI( int argc, char * argv[] )
+{
+	Inputs input;
+
+	// defaults to the history based simulation method
+	input.simulation_method = HISTORY_BASED;
+
+	// defaults to max threads on the system
+	input.nthreads = 1;
+
+	// defaults to 355 (corresponding to H-M Large benchmark)
+	input.n_isotopes = 355;
+
+	// defaults to 11303 (corresponding to H-M Large benchmark)
+	input.n_gridpoints = 11303;
+
+	// defaults to 500,000
+	input.particles = 500000;
+
+	// defaults to 34
+	input.lookups = 34;
+
+	// default to unionized grid
+	input.grid_type = UNIONIZED;
+
+	// default to unionized grid
+	input.hash_bins = 10000;
+
+	// default to no binary read/write
+	input.binary_mode = NONE;
+
+	// defaults to baseline kernel
+	input.kernel_id = 0;
+
+	// default to one kernel iteration
+	input.num_iterations = 1;
+
+	// default to zero warmup iterations
+	input.num_warmups = 1;
+
+  // default to stdout
+  input.filename = NULL;
+
+	// defaults to H-M Large benchmark
+	input.HM = (char *) malloc( 6 * sizeof(char) );
+	input.HM[0] = 'l' ;
+	input.HM[1] = 'a' ;
+	input.HM[2] = 'r' ;
+	input.HM[3] = 'g' ;
+	input.HM[4] = 'e' ;
+	input.HM[5] = '\0';
+
+	// Check if user sets these
+	int user_g = 0;
+
+	int default_lookups = 1;
+	int default_particles = 1;
+
+	// Collect Raw Input
+	for( int i = 1; i < argc; i++ )
+	{
+		char * arg = argv[i];
+
+		// n_gridpoints (-g)
+		if( strcmp(arg, "-g") == 0 )
+		{
+			if( ++i < argc )
+			{
+				user_g = 1;
+				input.n_gridpoints = atol(argv[i]);
+			}
+			else
+				print_CLI_error();
+		}
+		// Simulation Method (-m)
+		else if( strcmp(arg, "-m") == 0 )
+		{
+			char * sim_type;
+			if( ++i < argc )
+				sim_type = argv[i];
+			else
+				print_CLI_error();
+
+			if( strcmp(sim_type, "history") == 0 )
+				input.simulation_method = HISTORY_BASED;
+			else if( strcmp(sim_type, "event") == 0 )
+		{
+				input.simulation_method = EVENT_BASED;
+				// Also resets default # of lookups
+				if( default_lookups && default_particles )
+				{
+					input.lookups =  input.lookups * input.particles;
+					input.particles = 0;
+				}
+			}
+			else
+				print_CLI_error();
+		}
+		// lookups (-l)
+		else if( strcmp(arg, "-l") == 0 )
+		{
+			if( ++i < argc )
+			{
+				input.lookups = atoi(argv[i]);
+				default_lookups = 0;
+			}
+			else
+				print_CLI_error();
+		}
+		// hash bins (-h)
+		else if( strcmp(arg, "-h") == 0 )
+		{
+			if( ++i < argc )
+				input.hash_bins = atoi(argv[i]);
+			else
+				print_CLI_error();
+		}
+		// particles (-p)
+		else if( strcmp(arg, "-p") == 0 )
+		{
+			if( ++i < argc )
+			{
+				input.particles = atoi(argv[i]);
+				default_particles = 0;
+			}
+			else
+				print_CLI_error();
+		}
+		// HM (-s)
+		else if( strcmp(arg, "-s") == 0 )
+		{
+			if( ++i < argc )
+				input.HM = argv[i];
+			else
+				print_CLI_error();
+		}
+		// grid type (-G)
+		else if( strcmp(arg, "-G") == 0 )
+		{
+			char * grid_type;
+			if( ++i < argc )
+				grid_type = argv[i];
+			else
+				print_CLI_error();
+
+			if( strcmp(grid_type, "unionized") == 0 )
+				input.grid_type = UNIONIZED;
+			else if( strcmp(grid_type, "nuclide") == 0 )
+				input.grid_type = NUCLIDE;
+			else if( strcmp(grid_type, "hash") == 0 )
+				input.grid_type = HASH;
+			else
+				print_CLI_error();
+		}
+		// binary mode (-b)
+		else if( strcmp(arg, "-b") == 0 )
+		{
+			char * binary_mode;
+			if( ++i < argc )
+				binary_mode = argv[i];
+			else
+				print_CLI_error();
+
+			if( strcmp(binary_mode, "read") == 0 )
+				input.binary_mode = READ;
+			else if( strcmp(binary_mode, "write") == 0 )
+				input.binary_mode = WRITE;
+			else
+				print_CLI_error();
+		}
+		// kernel optimization selection (-k)
+		else if( strcmp(arg, "-k") == 0 )
+		{
+			if( ++i < argc )
+			{
+				input.kernel_id = atoi(argv[i]);
+			}
+			else
+				print_CLI_error();
+		}
+		// number of kernel iterations (-n)
+		else if( strcmp(arg, "-n") == 0 )
+		{
+			if( ++i < argc)
+			{
+				input.num_iterations = atoi(argv[i]);
+			}
+			else
+				print_CLI_error();
+		}
+		else if( strcmp(arg, "--csv") == 0 )
+		{
+			if( ++i < argc ) {
+        input.filename = (char *)malloc(strlen(argv[i]) + 1);
+        strcpy(input.filename, argv[i]);
+      }
+			else
+				print_CLI_error();
+    }
+		else if( strcmp(arg, "-w") == 0 )
+		{
+			if( ++i < argc)
+			{
+				input.num_warmups = atoi(argv[i]);
+			}
+			else
+				print_CLI_error();
+		}
+		else
+			print_CLI_error();
+	}
+
+	// Validate Input
+
+	// Validate nthreads
+	if( input.nthreads < 1 )
+		print_CLI_error();
+
+	// Validate n_isotopes
+	if( input.n_isotopes < 1 )
+		print_CLI_error();
+
+	// Validate n_gridpoints
+	if( input.n_gridpoints < 1 )
+		print_CLI_error();
+
+	// Validate lookups
+	if( input.lookups < 1 )
+		print_CLI_error();
+
+	// Validate Hash Bins
+	if( input.hash_bins < 1 )
+		print_CLI_error();
+
+	// Validate number of iterations
+	if ( input.num_iterations < 1 )
+		print_CLI_error();
+
+	// Validate HM size
+	if( strcasecmp(input.HM, "small") != 0 &&
+		strcasecmp(input.HM, "large") != 0 &&
+		strcasecmp(input.HM, "XL") != 0 &&
+		strcasecmp(input.HM, "XXL") != 0 )
+		print_CLI_error();
+
+	// Set HM size specific parameters
+	// (defaults to large)
+	if( strcasecmp(input.HM, "small") == 0 )
+		input.n_isotopes = 68;
+	else if( strcasecmp(input.HM, "XL") == 0 && user_g == 0 )
+		input.n_gridpoints = 238847; // sized to make 120 GB XS data
+	else if( strcasecmp(input.HM, "XXL") == 0 && user_g == 0 )
+		input.n_gridpoints = 238847 * 2.1; // 252 GB XS data
+
+	// Return input struct
+	return input;
+}
+
+void binary_write( Inputs in, SimulationData SD )
+{
+	const char * fname = "XS_data.dat";
+	printf("Writing all data structures to binary file %s...\n", fname);
+	FILE * fp = fopen(fname, "w");
+
+	// Write SimulationData Object. Include pointers, even though we won't be using them.
+	fwrite(&SD, sizeof(SimulationData), 1, fp);
+
+	// Write heap arrays in SimulationData Object
+	fwrite(SD.num_nucs,       sizeof(int), SD.length_num_nucs, fp);
+	fwrite(SD.concs,          sizeof(double), SD.length_concs, fp);
+	fwrite(SD.mats,           sizeof(int), SD.length_mats, fp);
+	fwrite(SD.nuclide_grid,   sizeof(NuclideGridPoint), SD.length_nuclide_grid, fp);
+	fwrite(SD.index_grid, sizeof(int), SD.length_index_grid, fp);
+	fwrite(SD.unionized_energy_array, sizeof(double), SD.length_unionized_energy_array, fp);
+
+	fclose(fp);
+}
+
+SimulationData binary_read( Inputs in )
+{
+	SimulationData SD;
+
+	const char * fname = "XS_data.dat";
+	printf("Reading all data structures from binary file %s...\n", fname);
+
+	FILE * fp = fopen(fname, "r");
+	assert(fp != NULL);
+
+	// Read SimulationData Object. Include pointers, even though we won't be using them.
+	fread(&SD, sizeof(SimulationData), 1, fp);
+
+	// Allocate space for arrays on heap
+	SD.num_nucs = (int *) malloc(SD.length_num_nucs * sizeof(int));
+	SD.concs = (double *) malloc(SD.length_concs * sizeof(double));
+	SD.mats = (int *) malloc(SD.length_mats * sizeof(int));
+	SD.nuclide_grid = (NuclideGridPoint *) malloc(SD.length_nuclide_grid * sizeof(NuclideGridPoint));
+	SD.index_grid = (int *) malloc( SD.length_index_grid * sizeof(int));
+	SD.unionized_energy_array = (double *) malloc( SD.length_unionized_energy_array * sizeof(double));
+
+	// Read heap arrays into SimulationData Object
+	fread(SD.num_nucs,       sizeof(int), SD.length_num_nucs, fp);
+	fread(SD.concs,          sizeof(double), SD.length_concs, fp);
+	fread(SD.mats,           sizeof(int), SD.length_mats, fp);
+	fread(SD.nuclide_grid,   sizeof(NuclideGridPoint), SD.length_nuclide_grid, fp);
+	fread(SD.index_grid, sizeof(int), SD.length_index_grid, fp);
+	fread(SD.unionized_energy_array, sizeof(double), SD.length_unionized_energy_array, fp);
+
+	fclose(fp);
+
+	return SD;
+}

--- a/targets/XSBench/kokkos/CMakeLists.txt
+++ b/targets/XSBench/kokkos/CMakeLists.txt
@@ -1,0 +1,42 @@
+cmake_minimum_required(VERSION 3.16)
+
+project(
+    XSBench_Kokkos
+    VERSION 1.0
+    LANGUAGES CXX
+)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+if(NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE Release)
+endif()
+
+set(CMAKE_CXX_FLAGS "-Wall -Wextra")
+set(CMAKE_CXX_FLAGS_DEBUG "-g")
+set(CMAKE_CXX_FLAGS_RELEASE "-O3")
+
+find_package(Kokkos REQUIRED)
+
+if (${KOKKOS_BACK_END} STREQUAL "CUDA")
+    enable_language(CUDA)
+    set(CMAKE_CUDA_STANDARD 17)
+
+    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -extended-lambda -Wext-lambda-captures-this -expt-relaxed-constexpr")
+
+    set_source_files_properties(${SOURCE} PROPERTIES LANGUAGE CUDA)
+elseif (${KOKKOS_BACK_END} STREQUAL "HIP")
+    enable_language(HIP)
+    set(CMAKE_HIP_STANDARD 17)
+
+    set_source_files_properties(${SOURCE} PROPERTIES LANGUAGE HIP)
+endif ()
+
+
+set(SOURCE Main.cpp io.cpp Simulation.cpp GridInit.cpp XSutils.cpp Materials.cpp)
+
+add_executable(XSBench ${SOURCE})
+target_link_libraries(XSBench Kokkos::kokkos)
+
+install(TARGETS XSBench DESTINATION bin)

--- a/targets/XSBench/kokkos/GridInit.cpp
+++ b/targets/XSBench/kokkos/GridInit.cpp
@@ -1,0 +1,177 @@
+#include "XSbench_header.hpp"
+
+SimulationData grid_init_do_not_profile( Inputs in, int mype )
+{
+	// Structure to hold all allocated simuluation data arrays
+	SimulationData SD;
+
+	// Keep track of how much data we're allocating
+	size_t nbytes = 0;
+
+	// Set the initial seed value
+	uint64_t seed = 42;
+
+	////////////////////////////////////////////////////////////////////
+	// Initialize Nuclide Grids
+	////////////////////////////////////////////////////////////////////
+
+	if(mype == 0) printf("Intializing nuclide grids...\n");
+
+	// First, we need to initialize our nuclide grid. This comes in the form
+	// of a flattened 2D array that hold all the information we need to define
+	// the cross sections for all isotopes in the simulation.
+	// The grid is composed of "NuclideGridPoint" structures, which hold the
+	// energy level of the grid point and all associated XS data at that level.
+	// An array of structures (AOS) is used instead of
+	// a structure of arrays, as the grid points themselves are accessed in
+	// a random order, but all cross section interaction channels and the
+	// energy level are read whenever the gridpoint is accessed, meaning the
+	// AOS is more cache efficient.
+
+	// Initialize Nuclide Grid
+	SD.length_nuclide_grid = in.n_isotopes * in.n_gridpoints;
+	SD.nuclide_grid     = (NuclideGridPoint *) malloc( SD.length_nuclide_grid * sizeof(NuclideGridPoint));
+	assert(SD.nuclide_grid != NULL);
+	nbytes += SD.length_nuclide_grid * sizeof(NuclideGridPoint);
+	for( int i = 0; i < SD.length_nuclide_grid; i++ )
+	{
+		SD.nuclide_grid[i].energy        = LCG_random_double(&seed);
+		SD.nuclide_grid[i].total_xs      = LCG_random_double(&seed);
+		SD.nuclide_grid[i].elastic_xs    = LCG_random_double(&seed);
+		SD.nuclide_grid[i].absorbtion_xs = LCG_random_double(&seed);
+		SD.nuclide_grid[i].fission_xs    = LCG_random_double(&seed);
+		SD.nuclide_grid[i].nu_fission_xs = LCG_random_double(&seed);
+	}
+
+	// Sort so that each nuclide has data stored in ascending energy order.
+	for( int i = 0; i < in.n_isotopes; i++ )
+		qsort( &SD.nuclide_grid[i*in.n_gridpoints], in.n_gridpoints, sizeof(NuclideGridPoint), NGP_compare);
+
+	// error debug check
+	/*
+	for( int i = 0; i < in.n_isotopes; i++ )
+	{
+		printf("NUCLIDE %d ==============================\n", i);
+		for( int j = 0; j < in.n_gridpoints; j++ )
+			printf("E%d = %lf\n", j, SD.nuclide_grid[i * in.n_gridpoints + j].energy);
+	}
+	*/
+
+
+	////////////////////////////////////////////////////////////////////
+	// Initialize Acceleration Structure
+	////////////////////////////////////////////////////////////////////
+
+	if( in.grid_type == NUCLIDE )
+	{
+		SD.length_unionized_energy_array = 0;
+		SD.length_index_grid = 0;
+	}
+
+	if( in.grid_type == UNIONIZED )
+	{
+		if(mype == 0) printf("Intializing unionized grid...\n");
+
+		// Allocate space to hold the union of all nuclide energy data
+		SD.length_unionized_energy_array = in.n_isotopes * in.n_gridpoints;
+		SD.unionized_energy_array = (double *) malloc( SD.length_unionized_energy_array * sizeof(double));
+		assert(SD.unionized_energy_array != NULL );
+		nbytes += SD.length_unionized_energy_array * sizeof(double);
+
+		// Copy energy data over from the nuclide energy grid
+		for( int i = 0; i < SD.length_unionized_energy_array; i++ )
+			SD.unionized_energy_array[i] = SD.nuclide_grid[i].energy;
+
+		// Sort unionized energy array
+		qsort( SD.unionized_energy_array, SD.length_unionized_energy_array, sizeof(double), double_compare);
+
+		// Allocate space to hold the acceleration grid indices
+		SD.length_index_grid = SD.length_unionized_energy_array * in.n_isotopes;
+		SD.index_grid = (int *) malloc( SD.length_index_grid * sizeof(int));
+		assert(SD.index_grid != NULL);
+		nbytes += SD.length_index_grid * sizeof(int);
+
+		// Generates the double indexing grid
+		int * idx_low = (int *) calloc( in.n_isotopes, sizeof(int));
+		assert(idx_low != NULL );
+		double * energy_high = (double *) malloc( in.n_isotopes * sizeof(double));
+		assert(energy_high != NULL );
+
+		for( int i = 0; i < in.n_isotopes; i++ )
+			energy_high[i] = SD.nuclide_grid[i * in.n_gridpoints + 1].energy;
+
+		for( long e = 0; e < SD.length_unionized_energy_array; e++ )
+		{
+			double unionized_energy = SD.unionized_energy_array[e];
+			for( long i = 0; i < in.n_isotopes; i++ )
+			{
+				if( unionized_energy < energy_high[i]  )
+					SD.index_grid[e * in.n_isotopes + i] = idx_low[i];
+				else if( idx_low[i] == in.n_gridpoints - 2 )
+					SD.index_grid[e * in.n_isotopes + i] = idx_low[i];
+				else
+				{
+					idx_low[i]++;
+					SD.index_grid[e * in.n_isotopes + i] = idx_low[i];
+					energy_high[i] = SD.nuclide_grid[i * in.n_gridpoints + idx_low[i] + 1].energy;
+				}
+			}
+		}
+
+		free(idx_low);
+		free(energy_high);
+	}
+
+	if( in.grid_type == HASH )
+	{
+		if(mype == 0) printf("Intializing hash grid...\n");
+		SD.length_unionized_energy_array = 0;
+		SD.length_index_grid  = in.hash_bins * in.n_isotopes;
+		SD.index_grid = (int *) malloc( SD.length_index_grid * sizeof(int));
+		assert(SD.index_grid != NULL);
+		nbytes += SD.length_index_grid * sizeof(int);
+
+		double du = 1.0 / in.hash_bins;
+
+		// For each energy level in the hash table
+		#pragma omp parallel for
+		for( long e = 0; e < in.hash_bins; e++ )
+		{
+			double energy = e * du;
+
+			// We need to determine the bounding energy levels for all isotopes
+			for( long i = 0; i < in.n_isotopes; i++ )
+			{
+				SD.index_grid[e * in.n_isotopes + i] = grid_search_nuclide_old( in.n_gridpoints, energy, SD.nuclide_grid + i * in.n_gridpoints, 0, in.n_gridpoints-1);
+			}
+		}
+	}
+
+	////////////////////////////////////////////////////////////////////
+	// Initialize Materials and Concentrations
+	////////////////////////////////////////////////////////////////////
+	if(mype == 0) printf("Intializing material data...\n");
+
+	// Set the number of nuclides in each material
+	SD.num_nucs  = load_num_nucs(in.n_isotopes);
+	SD.length_num_nucs = 12; // There are always 12 materials in XSBench
+
+	// Intialize the flattened 2D grid of material data. The grid holds
+	// a list of nuclide indices for each of the 12 material types. The
+	// grid is allocated as a full square grid, even though not all
+	// materials have the same number of nuclides.
+	SD.mats = load_mats(SD.num_nucs, in.n_isotopes, &SD.max_num_nucs);
+	SD.length_mats = SD.length_num_nucs * SD.max_num_nucs;
+
+	// Intialize the flattened 2D grid of nuclide concentration data. The grid holds
+	// a list of nuclide concentrations for each of the 12 material types. The
+	// grid is allocated as a full square grid, even though not all
+	// materials have the same number of nuclides.
+	SD.concs = load_concs(SD.num_nucs, SD.max_num_nucs);
+	SD.length_concs = SD.length_mats;
+
+	if(mype == 0) printf("Intialization complete. Allocated %.0lf MB of data.\n", nbytes/1024.0/1024.0 );
+
+	return SD;
+
+}

--- a/targets/XSBench/kokkos/Main.cpp
+++ b/targets/XSBench/kokkos/Main.cpp
@@ -1,0 +1,120 @@
+#include "XSbench_header.hpp"
+
+#ifdef MPI
+#include<mpi.h>
+#endif
+
+int main( int argc, char* argv[] )
+{
+	// =====================================================================
+	// Initialization & Command Line Read-In
+	// =====================================================================
+	int version = 20;
+	int mype = 0;
+	int nprocs = 1;
+	unsigned long long verification;
+
+	#ifdef MPI
+	MPI_Status stat;
+	MPI_Init(&argc, &argv);
+	MPI_Comm_size(MPI_COMM_WORLD, &nprocs);
+	MPI_Comm_rank(MPI_COMM_WORLD, &mype);
+	#endif
+
+	Profile profile;
+
+        // Start Kokkos
+        Kokkos::initialize();
+
+	// Process CLI Fields -- store in "Inputs" structure
+	Inputs in = read_CLI( argc, argv );
+
+	// Set number of OpenMP Threads
+	//omp_set_num_threads(in.nthreads);
+
+	// Print-out of Input Summary
+	if( mype == 0 )
+		print_inputs( in, nprocs, version );
+
+	// =====================================================================
+	// Prepare Nuclide Energy Grids, Unionized Energy Grid, & Material Data
+	// This is not reflective of a real Monte Carlo simulation workload,
+	// therefore, do not profile this region!
+	// =====================================================================
+
+	SimulationData SD;
+
+	// If read from file mode is selected, skip initialization and load
+	// all simulation data structures from file instead
+	if( in.binary_mode == READ )
+		SD = binary_read(in);
+	else
+		SD = grid_init_do_not_profile( in, mype );
+
+	// If writing from file mode is selected, write all simulation data
+	// structures to file
+	if( in.binary_mode == WRITE && mype == 0 )
+		binary_write(in, SD);
+
+
+	// =====================================================================
+	// Cross Section (XS) Parallel Lookup Simulation
+	// This is the section that should be profiled, as it reflects a
+	// realistic continuous energy Monte Carlo macroscopic cross section
+	// lookup kernel.
+	// =====================================================================
+
+	if( mype == 0 )
+	{
+		printf("\n");
+		border_print();
+		center_print("SIMULATION", 79);
+		border_print();
+	}
+
+	// Start Simulation Timer
+	double elapsed_time = 0;
+
+	// Run simulation
+	if( in.simulation_method == EVENT_BASED )
+	{
+		if( in.kernel_id == 0 )
+			verification = run_event_based_simulation(in, SD, mype, &elapsed_time, &profile);
+		else
+		{
+			printf("Error: No kernel ID %d found!\n", in.kernel_id);
+			exit(1);
+		}
+	}
+	else
+	{
+		printf("History-based simulation not implemented in Kokkos code. Instead,\nuse the event-based method with \"-m event\" argument.\n");
+		exit(1);
+	}
+
+	if( mype == 0)
+	{
+		printf("\n" );
+		printf("Simulation complete.\n" );
+	}
+
+	// =====================================================================
+	// Output Results & Finalize
+	// =====================================================================
+
+	// Final Hash Step
+	verification = verification % 999983;
+
+	// Print / Save Results and Exit
+	int is_invalid_result = print_results( in, mype, elapsed_time, nprocs, verification );
+
+        Kokkos::finalize();
+
+	#ifdef MPI
+	MPI_Finalize();
+	#endif
+
+	print_profile(profile, in);
+
+	return is_invalid_result;
+}

--- a/targets/XSBench/kokkos/Makefile
+++ b/targets/XSBench/kokkos/Makefile
@@ -1,0 +1,114 @@
+#===============================================================================
+# User Options
+#===============================================================================
+
+KOKKOS_PATH ?= /global/homes/j/jhdavis/XSBench/kokkos/kokkos
+CUDA_PATH   ?= ${CUDA_HOME}
+COMPILER    ?= gnu
+OPTIMIZE    ?= yes
+DEBUG       ?= no
+PROFILE     ?= no
+MPI         ?= no
+KOKKOS_DEVICES ?= OpenMP,Cuda
+KOKKOS_ARCH ?= Zen3,Ampere80
+SM_VERSION ?= 80
+
+#===============================================================================
+# Program name & source code list
+#===============================================================================
+
+program = XSBench
+
+source = \
+Main.cpp \
+io.cpp \
+Simulation.cpp \
+GridInit.cpp \
+XSutils.cpp \
+Materials.cpp
+
+obj = $(source:.cpp=.o)
+
+#===============================================================================
+# Sets Flags
+#===============================================================================
+
+# Standard Flags
+CXXFLAGS := -Wall
+
+# Linker Flags
+LDFLAGS = -lm
+
+# NVIDIA Compiler
+ifeq ($(COMPILER),nvidia)
+  CXX = ${KOKKOS_PATH}/bin/nvcc_wrapper
+  CXXFLAGS += -ccbin nvc++ -Xcompiler -Wall -Xcompiler -O3 -arch=sm_$(SM_VERSION)
+endif
+
+# Clang Compiler
+ifeq ($(COMPILER),llvm)
+  CXX = clang++
+  CXXFLAGS += -flto -fopenmp -DOPENMP
+endif
+
+# GCC Compiler
+ifeq ($(COMPILER),gnu)
+  ifneq (,$(findstring Cuda,$(KOKKOS_DEVICES)))
+    CXX = ${KOKKOS_PATH}/bin/nvcc_wrapper
+    CXXFLAGS += -ccbin g++ -Xcompiler -Wall -Xcompiler -O3 -arch=sm_$(SM_VERSION) -Xcompiler -fopenmp -DOPENMP
+  else
+    CXX = g++
+    CXXFLAGS += -flto -fopenmp -DOPENMP
+  endif
+endif
+
+
+# Debug Flags
+ifeq ($(DEBUG),yes)
+  CXXFLAGS += -g
+  LDFLAGS  += -g
+ifeq ($(COMPILER),nvidia)
+  CXXFLAGS += -G
+  LDFLAGS  += -G
+endif
+endif
+
+# Profiling Flags
+ifeq ($(PROFILE),yes)
+  CXXFLAGS += -pg
+  LDFLAGS  += -pg
+endif
+
+# Optimization Flags
+ifeq ($(OPTIMIZE),yes)
+  CXXFLAGS += -O3
+endif
+
+# MPI
+ifeq ($(MPI),yes)
+  CXX = mpicxx
+  CXXFLAGS += -DMPI
+endif
+
+#===============================================================================
+# Targets to Build
+#===============================================================================
+
+default: $(program)
+
+include $(KOKKOS_PATH)/Makefile.kokkos
+
+$(program): $(obj) XSbench_header.hpp Makefile $(KOKKOS_LINK_DEPENDS)
+	$(CXX) $(CXXFLAGS) $(KOKKOS_LDFLAGS) $(obj) $(KOKKOS_LIBS) -o $@ $(LDFLAGS)
+
+%.o: %.cpp XSbench_header.hpp Makefile $(KOKKOS_CPP_DEPENDS)
+	$(CXX) $(KOKKOS_CPPFLAGS) $(KOKKOS_CXXFLAGS) $(CXXFLAGS) -c $< -o $@
+
+clean:
+	rm -rf $(program) $(obj) *.tmp Kokkos* desul/ libkokkos.a Lock_Array_CUDA.o
+
+edit:
+	vim -p $(source) XSbench_header.hpp
+
+run:
+	./$(program)

--- a/targets/XSBench/kokkos/Materials.cpp
+++ b/targets/XSBench/kokkos/Materials.cpp
@@ -1,0 +1,117 @@
+// Material data is hard coded into the functions in this file.
+// Note that there are 12 materials present in H-M (large or small)
+
+#include "XSbench_header.hpp"
+
+// num_nucs represents the number of nuclides that each material contains
+int * load_num_nucs(long n_isotopes)
+{
+	int * num_nucs = (int*)malloc(12*sizeof(int));
+
+	// Material 0 is a special case (fuel). The H-M small reactor uses
+	// 34 nuclides, while H-M larges uses 300.
+	if( n_isotopes == 68 )
+		num_nucs[0]  = 34; // HM Small is 34, H-M Large is 321
+	else
+		num_nucs[0]  = 321; // HM Small is 34, H-M Large is 321
+
+	num_nucs[1]  = 5;
+	num_nucs[2]  = 4;
+	num_nucs[3]  = 4;
+	num_nucs[4]  = 27;
+	num_nucs[5]  = 21;
+	num_nucs[6]  = 21;
+	num_nucs[7]  = 21;
+	num_nucs[8]  = 21;
+	num_nucs[9]  = 21;
+	num_nucs[10] = 9;
+	num_nucs[11] = 9;
+
+	return num_nucs;
+}
+
+// Assigns an array of nuclide ID's to each material
+int * load_mats( int * num_nucs, long n_isotopes, int * max_num_nucs )
+{
+	*max_num_nucs = 0;
+	int num_mats = 12;
+	for( int m = 0; m < num_mats; m++ )
+	{
+		if( num_nucs[m] > *max_num_nucs )
+			*max_num_nucs = num_nucs[m];
+	}
+	int * mats = (int *) malloc( num_mats * (*max_num_nucs) * sizeof(int) );
+
+	// Small H-M has 34 fuel nuclides
+	int mats0_Sml[] =  { 58, 59, 60, 61, 40, 42, 43, 44, 45, 46, 1, 2, 3, 7,
+			 8, 9, 10, 29, 57, 47, 48, 0, 62, 15, 33, 34, 52, 53,
+			 54, 55, 56, 18, 23, 41 }; //fuel
+	// Large H-M has 300 fuel nuclides
+	int mats0_Lrg[321] =  { 58, 59, 60, 61, 40, 42, 43, 44, 45, 46, 1, 2, 3, 7,
+			 8, 9, 10, 29, 57, 47, 48, 0, 62, 15, 33, 34, 52, 53,
+			 54, 55, 56, 18, 23, 41 }; //fuel
+	for( int i = 0; i < 321-34; i++ )
+		mats0_Lrg[34+i] = 68 + i; // H-M large adds nuclides to fuel only
+
+	// These are the non-fuel materials
+	int mats1[] =  { 63, 64, 65, 66, 67 }; // cladding
+	int mats2[] =  { 24, 41, 4, 5 }; // cold borated water
+	int mats3[] =  { 24, 41, 4, 5 }; // hot borated water
+	int mats4[] =  { 19, 20, 21, 22, 35, 36, 37, 38, 39, 25, 27, 28, 29,
+			 30, 31, 32, 26, 49, 50, 51, 11, 12, 13, 14, 6, 16,
+			 17 }; // RPV
+	int mats5[] =  { 24, 41, 4, 5, 19, 20, 21, 22, 35, 36, 37, 38, 39, 25,
+			 49, 50, 51, 11, 12, 13, 14 }; // lower radial reflector
+	int mats6[] =  { 24, 41, 4, 5, 19, 20, 21, 22, 35, 36, 37, 38, 39, 25,
+			 49, 50, 51, 11, 12, 13, 14 }; // top reflector / plate
+	int mats7[] =  { 24, 41, 4, 5, 19, 20, 21, 22, 35, 36, 37, 38, 39, 25,
+			 49, 50, 51, 11, 12, 13, 14 }; // bottom plate
+	int mats8[] =  { 24, 41, 4, 5, 19, 20, 21, 22, 35, 36, 37, 38, 39, 25,
+			 49, 50, 51, 11, 12, 13, 14 }; // bottom nozzle
+	int mats9[] =  { 24, 41, 4, 5, 19, 20, 21, 22, 35, 36, 37, 38, 39, 25,
+			 49, 50, 51, 11, 12, 13, 14 }; // top nozzle
+	int mats10[] = { 24, 41, 4, 5, 63, 64, 65, 66, 67 }; // top of FA's
+	int mats11[] = { 24, 41, 4, 5, 63, 64, 65, 66, 67 }; // bottom FA's
+
+	// H-M large v small dependency
+	if( n_isotopes == 68 )
+		memcpy( mats,  mats0_Sml,  num_nucs[0]  * sizeof(int) );
+	else
+		memcpy( mats,  mats0_Lrg,  num_nucs[0]  * sizeof(int) );
+
+	// Copy other materials
+	memcpy( mats + *max_num_nucs * 1,  mats1,  num_nucs[1]  * sizeof(int) );
+	memcpy( mats + *max_num_nucs * 2,  mats2,  num_nucs[2]  * sizeof(int) );
+	memcpy( mats + *max_num_nucs * 3,  mats3,  num_nucs[3]  * sizeof(int) );
+	memcpy( mats + *max_num_nucs * 4,  mats4,  num_nucs[4]  * sizeof(int) );
+	memcpy( mats + *max_num_nucs * 5,  mats5,  num_nucs[5]  * sizeof(int) );
+	memcpy( mats + *max_num_nucs * 6,  mats6,  num_nucs[6]  * sizeof(int) );
+	memcpy( mats + *max_num_nucs * 7,  mats7,  num_nucs[7]  * sizeof(int) );
+	memcpy( mats + *max_num_nucs * 8,  mats8,  num_nucs[8]  * sizeof(int) );
+	memcpy( mats + *max_num_nucs * 9,  mats9,  num_nucs[9]  * sizeof(int) );
+	memcpy( mats + *max_num_nucs * 10, mats10, num_nucs[10] * sizeof(int) );
+	memcpy( mats + *max_num_nucs * 11, mats11, num_nucs[11] * sizeof(int) );
+
+
+	return mats;
+}
+
+// Randomizes the concentrations of all nuclides in a variety of materials
+double * load_concs( int * num_nucs, int max_num_nucs )
+{
+	uint64_t seed = STARTING_SEED * STARTING_SEED;
+	double * concs = (double *) malloc( 12 * max_num_nucs * sizeof( double ) );
+
+	for( int i = 0; i < 12; i++ )
+		for( int j = 0; j < num_nucs[i]; j++ )
+			concs[i * max_num_nucs + j] = LCG_random_double(&seed);
+
+	// test
+	/*
+	for( int i = 0; i < 12; i++ )
+		for( int j = 0; j < num_nucs[i]; j++ )
+			printf("concs[%d][%d] = %lf\n", i, j, concs[i][j] );
+	*/
+
+	return concs;
+}

--- a/targets/XSBench/kokkos/README.md
+++ b/targets/XSBench/kokkos/README.md
@@ -1,0 +1,239 @@
+![XSBench](docs/img/logo.png)
+
+[![Latest Github release](https://img.shields.io/github/release/ANL-CESAR/XSBench.svg)](https://github.com/ANL-CESAR/XSBench/releases/latest)
+[![Build Status](https://travis-ci.com/ANL-CESAR/XSBench.svg?branch=master)](https://travis-ci.com/ANL-CESAR/XSBench)
+[![Published in Annals of Nuclear Energy](https://img.shields.io/badge/Published%20in-Annals%20of%20Nuclear%20Energy-167DA4.svg)](https://www.sciencedirect.com/science/article/pii/S0306454914004332)
+
+XSBench is a mini-app representing a key computational kernel of the Monte Carlo neutron transport algorithm. Specifically, XSBench represents the continuous energy macroscopic neutron cross section lookup kernel. XSBench serves as a lightweight stand-in for full neutron transport applications like [OpenMC](https://github.com/openmc-dev/openmc), and is a useful tool for performance analysis on high performance computing architectures.
+
+## Table of Contents
+
+1. [Selecting a Programming Model](#selecting-a-programming-model)
+2. [Compilation](#Compilation)
+3. [Running XSBench / Command Line Interface](#Running-XSBench)
+4. [Feature Discussion](#Feature-Discussion)
+	* [MPI Support](#MPI-Support)
+	* [Verification Support](#Verification-Support)
+	* [Binary File Support](#Binary-File-Support)
+5. [Theory & Algorithms](#Algorithms)
+	* [Transport Simulation Styles](#Transport-Simulation-Styles)
+		- [History-Based Transport](#History-Based-Transport)
+		- [Event-Based Transport](#Event-Based-Transport)
+	* [Cross Section Lookup Methods](#Cross-Section-Lookup-Methods)
+		- [Nuclide Grid](#Nuclide-Grid)
+		- [Unionized Energy Grid](#Unionized-Energy-Grid)
+		- [Logarithmic Hash Grid](#Logarithmic-Hash-Grid)
+6. [Citing XSBench](#Citing-XSBench)
+7. [Development Team](#Development-Team) 
+
+## Selecting A Programming Model
+
+XSBench has been implemented in Kokkos to target a variety of computational architectures and accelerators.
+
+## Compilation
+
+To compile XSBench with default settings, navigate to your selected source directory and use the following command:
+
+```bash
+make
+```
+ 
+ You can alter compiler settings in the included Makefile.
+
+### Debugging, Optimization & Profiling
+
+There are also a number of switches that can be set in the makefile. Here is a sample of the control panel at the top of the makefile:
+
+```make
+OPTIMIZE = yes
+DEBUG    = no
+PROFILE  = no
+MPI      = no
+```
+- Optimization enables the -O3 optimization flag.
+- Debugging enables the -g flag.
+- Profiling enables the -pg flag. When profiling the code, you may
+wish to significantly increase the number of lookups (with the -l
+flag) in order to wash out the initialization phase of the code.
+- MPI enables MPI support in the code.
+
+## Running XSBench
+
+To run XSBench with default settings, use the following command:
+```bash
+./XSBench
+```
+For non-default settings, XSBench supports the following command line options:
+
+| Argument    |Description | Options     | Default
+|-------------|------------|---------------|------------|
+|-m           |Simulation method| history, event| history|
+|-s | Problem Size | small, large, XL, XXL | large|
+|-g | # of gridpoints per nuclide (overrides -s defaults) | integer value| 11,303 |
+-G | Grid search type | unionized, nuclide, hash | unionized |
+-p | # of particle histories (if running using "history" method)| integer value | 500,000 |
+-l | # of Cross-section (XS) lookups. If using history based method, this is lookups per particle history. If using event-based method, this is total lookups. | integer value | (History: 34) (Event: 17,000,000) |
+-h | # of hash bins (only used with hash-based grid search) | integer value | 10,000 |
+-b | Read/Write binary files | read, write |  |
+
+- **-m [simulation method]**
+Sets the simulation method, either "history" or "event". These options represent the history based or event based algorithms respectively. The default is the history based method. These two methods represent different methods of parallelizing the Monte Carlo transport method. In the history based method, the central mode of parallelism is expressed over particles, which each require some number of macroscopic cross sections to be executed in series and in a dependent order. The event based method expresses its parallelism over a large pool of independent macroscopic cross section lookups that can be executed in any order without dependence. They key difference between the two methods is the dependence/independence of the macroscopic cross section loop. See the [Transport Simulation Styles](#Transport-Simulation-Styles) section for more information.
+
+- **-s [size]**
+Sets the size of the Hoogenboom-Martin reactor model. There are four options: 'small', 'large', 'XL', and 'XXL'. By default, the 'large' option is selected. The H-M size corresponds to the number of nuclides present in the fuel region. The small version has 34 fuel nuclides, whereas the large version has 321 fuel nuclides. This significantly slows down the runtime of the program as the data structures are much larger, and more lookups are required whenever a lookup occurs in a fuel material. Note that the program defaults to "Large" if no specification is made. The additional size options, "XL" and "XXL", do not directly correspond to any particular physical model. They are similar to the H-M "large" option, except the number of gridpoints per nuclide has been increased greatly. This creates an extremely large energy grid data structure (XL: 120GB, XXL: 252GB), which is unlikely to fit on a single node, but is useful for experimentation purposes on novel architectures.
+
+- **-g [gridpoints]**
+Sets the number of gridpoints per nuclide. By default, this value is set to 11,303. This corresponds to the average number of actual gridpoints per nuclide in the H-M Large model as run by OpenMC with the actual ACE ENDF cross-section data. Note that this option will override the number of default gridpoints as set by the '-s' option.
+
+- **-G [grid type]**
+Sets the grid search type (unionized, nuclide, hash). Defaults to unionized. The unionized grid is what is typically used in Monte Carlo codes, as it offers the fastest speed. However, the increase in speed comes in a significant increase in memory usage as a union of all the separate nuclide grids must be formed and stored in memory. The "nuclide" mode uses only the basic nuclide grid data, with no unionization. This is slower as a binary search must be performed on every nuclide for each macroscopic XS lookup, rather than only once when using the unionized grid. Finally, the "hash" mode is a newer algorithm now used by many full Monte Carlo codes which offers speed nearly equivalent to the unionized energy grid method, but with only a small fraction of the memory overhead. See the [Cross Section Lookup Methods](#Cross-Section-Lookup-Methods) section for more details.
+
+- **-p [particles]**
+Sets the number of particle histories to simulate. By default, this value is set to 500,000. Users may want to increase this value if they wish to extend the runtime of XSBench, perhaps to produce more reliable performance counter data - as extending the run will decrease the percentage of runtime spent on initialization. Real MC simulations in a full application may use up to several billion particles per generation, so there is great flexibility in this variable.
+
+- **-l [lookups]**
+Sets the number of cross-section (XS) lookups to perform per particle. By default, this value is set to 34, which represents the average number of XS lookups per particle over the course of its lifetime in a light water reactor problem. Users should only alter this value if they are trying to capture the behavior of a different type of reactor (e.g., one with a fast spectrum), where the number of lookups per history may be different.
+
+- **-h [hash bins]**
+Sets the number of hash bins (only relevant when using the hash lookup algorithm, as selected with "-G hash"). Default is 10,000.
+
+- **-b [binary mode]**
+This optional mode can read or write the simulation data structures to disk. Options are ("read" or "write"). This may be useful if it is necessary to minimize the initialization phase of the program, which has a non-trivial runtime. The generated file is named "XS_data.dat" and will be located in the current working directory. The same file name and location will be used when reading. Note that as the file is binary, it may not be portable between compilers and computer systems. NOTE: When running in the "read" mode, you must be running with an identical program configuration as when the file was generated. E.g., if the file was generated with the "-G nuclide" argument, subsequent runs reading from that file must use the same configuration flags.
+
+## Feature Discussion
+
+### MPI Support
+
+While XSBench is primarily used to investigate "on node parallelism" issues, some systems provide power & performance statistics batched in multi-node configurations. To accommodate this, XSBench provides an MPI mode which runs the code on all MPI ranks simultaneously. There is no decomposition across ranks of any kind, and all ranks accomplish the same work. This is a "weak scaling" approach -- for instance, if running the event-based model all MPI ranks will execute 17,000,000 cross section lookups regardless of how many ranks are used. There is only one point of MPI communication (a reduce) at the end, which aggregates the timing statistics and averages them across MPI ranks before printing them out. MPI support can be enabled with the makefile flag "MPI". If you are not using the mpicc wrapper on your system, you may need to alter the makefile to make use of your desired compiler.
+
+### Verification Support
+
+Legacy versions of XSBench had a special "Verification" compiler flag option to enable verification of the results. However, a much more performant and portable verification scheme was developed and is now used for all configurations -- therefore, it is not necessary to compile with or without the verification mode as it is always enabled by default. XSBench generates a hash of the results at the end of the simulation and displays it with the other data once the code has completed executing. This hash can then be verified against hashes that other versions or configurations of the code generate. For instance, running XSBench with 4 threads vs 8 threads (on a machine that supports that configuration) should generate the same hash number. Running on GPU vs CPU should not change the hash number. However, changing the model / run parameters is expected to generate a totally different hash number (i.e., increasing the number of particles, number of gridpoints, etc, will result in different hashes). However, changing the type of lookup performed (e.g., nuclide, unionized, or hash) should result in the same hash being generated. Changing the simulation mode (history or event) will generate different hashes.
+
+### Binary File Support
+
+Instead of initializing the randomized synthetic cross section data structres in XSBench everytime it is run, you may optionally have XSBench generate a data set and write it to file. It can then be read on subsequent runs to speed up initialization. This process is controlled with the "-b (read, write)" command line argument. This feature may be extremely useful for users running on simulators where walltime minimization is critical for logistical purposes, or for users who are doing many sequential runs. Note that identical input parameters (problem size, solution method etc) must be used when reading and writing a binary file. No runtime checks are made to validate that the file correctly corresponds to the selected input parameters.
+
+
+## Algorithms
+
+### Transport Simulation Styles
+
+#### History-Based Transport
+
+The default simulation model used in XSBench is the "history-based" model. In this model, parallelism is expressed over independent particle histories, with each particle being simulated in a serial fashion from birth to death: 
+
+```c
+for each particle do		   // Independent
+	while particle is alive do // Dependent
+		Move particle to collision site
+		Process particle collision
+```
+
+This method of parallelism is very memory efficient, as the total number of particles that must be kept in memory at once is equivalent to the total number of active threads being run in the simulation. However, as there are many different types of collision events, the history-based model means that there is no natural SIMD style parallelism available for work happening between different threads.
+
+#### Event-Based Transport
+
+An alternative simulation model is the "event-based" model. In this model, parallelism is instead expressed over different collision (or "event") types. To facilitate this, all particles in the simulation are stored in memory at once. Each event kernel is executed in parallel on vectors of particles that currently require that event to be executed:
+
+```c
+Get vector of source particles
+while any particles are alive do	     // Dependent
+	for each living particle do          // Independent
+		Move particle to collision site
+	for each living particle do          // Independent
+		Process particle collision
+	Sort/consolidate surviving particles
+```
+This method of parallelism is requires more memory and requires an extra stream compaction kernel to sort and organize the particles periodically to ready them for the different event kernels. The benefit of this model is that kernels can potentially be execute in a SIMD manner and with higher cache efficiency due to the potential to sort particles by material and energy. On CPU architectures, the costs of sorting and buffering particles typically outweigh the benefits of the event-based model, but on accelerator architectures the tradeoff has been found to usually be more favorable.
+
+### Cross Section (XS) Lookup Methods
+
+XSBench represents the macroscopic cross section lookup kernel. This kernel is responsible for adding together microscopic cross section data from all nuclides present in the material the neutron is travelling through, given a certain energy:
+
+<p align="center"> <img src="docs/img/XS_equation.svg" alt="XS_Lookup_EQ" width="500"/> </p>
+
+Macroscopic cross section data is typically required for multiple reaction channels "c", such as the total cross section, fission cross section, etc. This data is typically stored in point-wise data form for each nuclide. There are multiple ways of accessesing this data in an efficient manner which will be discusses in this section.
+
+#### Nuclide Grid
+
+This is the default "naive" method of performing macroscopic XS lookups. XS data is stored for a number of energy levels for each nuclide in the simulation problem. Different nuclides can have a different number of energy levels. For instance, U-238 usually has over 100k energy levels, whereas some other nuclides may only have a few thousand. The "Nuclide Grid" is composed of all nuclides in the problem, with a variable number of data points for each nuclide. Each data point is composed of the energy level and accompanying cross section data for multiple different reaction channels:
+
+<p align="center"> <img src="docs/img/xs_point.png" alt="xs_point" width="300"/> </p>
+
+These XS data points are arranged into the nuclide grid:
+
+<p align="center"> <img src="docs/img/nuclide_grid.png" alt="nuclide_grid" width="350"/> </p>
+
+When assembling a macroscopic cross section data point, we will be accessing and interpolating data from the nuclide grid for a neutron travelling through a given material (composed of some number of nuclides) and at a given energy level. This will involve performing a binary search for each nuclide:
+
+```
+Nuclide_Grid_Search( Energy E, Material M ):
+	macroscopic XS = 0
+	for each nuclide in M do:
+		index = binary search to find E in nuclide grid
+		interpolate data from grid[nuclide, index]
+		macroscopic XS += data
+```
+
+This algorithm requires no extra memory usage beyond the minimum to represent the pointwise cross section data, but also requires that a binary search be run for each nuclide in the material the neutron is travelling through. In the case of depleted fuel, there can be 300+ nuclides, making this option computationally expensive.
+
+#### Unionized Energy Grid
+
+One way of speeding up the nuclide grid search is to form a separate acceleration structure to reduce the number of binary searches that need to be performed. In the Unionized Energy Grid (EUG) method, a second grid is created with columns corresponding to the **union** of all energy levels from the nuclide grid. For each energy level (column) in the unionized grid, each row stores an index corresponding to the closest location in the nuclide grid for each nuclide corresponding that energy level:
+
+<p align="center"> <img src="docs/img/UEG.png" alt="UEG" width="500"/> </p>
+
+A lookup using the UEG therefore requires only one single binary search on the unionized grid, allowing then for fast accesses using the indices stored at that energy level:
+
+```
+Unionized_Grid_Search( Energy E, Material M ):
+	macroscopic XS = 0
+	UEG_index = binary search to find E in unionized grid
+	for each nuclide in M do:
+		index = unionized_grid[nuclide, UEG_index]
+		interpolate data from grid[nuclide, index]
+		macroscopic XS += data
+```
+
+#### Logarithmic Hash Grid
+
+An alternative to the unionized energy grid is the logarithmic hash grid. This method takes in account the fact that while nuclides will be tabulated on grids containing different numbers of energy points, the points within each nuclide's grid will in general be spaced in (roughly) uniform maner in log space . Therefore, the nuclide grid is augmented with a separate acceleration structure similar to the unionized grid. However, the number of columns is capped at some number of bins spaced evenly in log space, with each row therefore corresponding to an approximate location within each nuclide's grid for that energy level. While the unionized grid points exactly to the correct index in the nuclide grid, the logarithmic hash grid points to only an approximate location below the true point -- meaning that a fast binary or iterative search must still be performed over the constrained area (typically only 10 or so elements in size):
+
+```
+Logarithmic_Hash_Grid_Search( Energy E, Material M ):
+	macroscopic XS = 0
+	hash_index = grid_delta * (ln(E) - grid_minimum_energy)
+	for each nuclide in M do:
+		i_low  = unionized_grid[nuclide, hash_index]
+		i_high = unionized_grid[nuclide, hash_index+1]
+		index = binary search in range(i_low, i_high) to find E in nuclide grid
+		interpolate data from grid[nuclide, index]
+		macroscopic XS += data
+```
+
+Compared to the unionized energy grid method, the logarithmic hash method uses far less memory but typically results in competitive performance. More details on this method can be found in the following publication:
+   
+>Forrest B Brown. New hash-based energy lookup algorithm for monte carlo codes. Trans. Am. Nucl. Soc., 111:659–662, 2014. http://permalink.lanl.gov/object/tr?what=info:lanl-repo/lareport/LA-UR-14-27037
+
+## Citing XSBench
+
+Papers citing the XSBench program in general should refer to:
+
+>J. R. Tramm, A. R. Siegel, T. Islam, and M. Schulz, “XSBench - The Development and Verification of a Performance Abstraction for Monte Carlo Reactor Analysis,” presented at PHYSOR 2014 - The Role of Reactor Physics toward a Sustainable Future, Kyoto. https://www.mcs.anl.gov/papers/P5064-0114.pdf
+
+Bibtex Entry:
+
+```bibtex
+@inproceedings{Tramm:wy,
+author = {Tramm, John R and Siegel, Andrew R and Islam, Tanzima and Schulz, Martin},
+title = {{XSBench} - The Development and Verification of a Performance Abstraction for {M}onte {C}arlo Reactor Analysis},
+booktitle = {{PHYSOR} 2014 - The Role of Reactor Physics toward a Sustainable Future},
+address = {Kyoto},
+year = 2014,
+url = "https://www.mcs.anl.gov/papers/P5064-0114.pdf"
+}
+```
+
+## Development Team
+Authored and maintained by John Tramm ([@jtramm](https://github.com/jtramm)) with help from Ron Rahaman, Amanda Lund, and other [contributors](https://github.com/ANL-CESAR/XSBench/graphs/contributors).

--- a/targets/XSBench/kokkos/Simulation.cpp
+++ b/targets/XSBench/kokkos/Simulation.cpp
@@ -1,0 +1,506 @@
+#include "XSbench_header.hpp"
+
+////////////////////////////////////////////////////////////////////////////////////
+// BASELINE FUNCTIONS
+////////////////////////////////////////////////////////////////////////////////////
+// All "baseline" code is at the top of this file. The baseline code is a simple
+// implementation of the algorithm, with only minor CPU optimizations in place.
+// Following these functions are a number of optimized variants,
+// which each deploy a different combination of optimizations strategies. By
+// default, XSBench will only run the baseline implementation. Optimized variants
+// are not yet implemented for this OpenMP targeting offload port.
+////////////////////////////////////////////////////////////////////////////////////
+
+unsigned long long run_event_based_simulation(Inputs in, SimulationData SD, int mype, double* end, Profile* profile)
+{
+	if( mype == 0)
+		printf("Beginning event based simulation...\n");
+	////////////////////////////////////////////////////////////////////////////////
+	// SUMMARY: Simulation Data Structure Manifest for "SD" Object
+	// Here we list all heap arrays (and lengths) in SD that would need to be
+	// offloaded manually if using an accelerator with a seperate memory space
+	////////////////////////////////////////////////////////////////////////////////
+	// int * num_nucs;                     // Length = length_num_nucs;
+	// double * concs;                     // Length = length_concs
+	// int * mats;                         // Length = length_mats
+	// double * unionized_energy_array;    // Length = length_unionized_energy_array
+	// int * index_grid;                   // Length = length_index_grid
+	// NuclideGridPoint * nuclide_grid;    // Length = length_nuclide_grid
+	//
+	// Note: "unionized_energy_array" and "index_grid" can be of zero length
+	//        depending on lookup method.
+	//
+	// Note: "Lengths" are given as the number of objects in the array, not the
+	//       number of bytes.
+	////////////////////////////////////////////////////////////////////////////////
+
+	// Data movment and setup
+	int length_max_num_nucs = 1;
+
+	Kokkos::Timer start;
+	start.reset();
+
+	double startP = get_time();
+
+
+        UIntView u_num_nucs(SD.num_nucs, SD.length_num_nucs);
+        SD.d_num_nucs = new IntView(Kokkos::ViewAllocateWithoutInitializing("d_num_nucs"), SD.length_num_nucs);
+        Kokkos::deep_copy(*SD.d_num_nucs, u_num_nucs);
+
+        UDoubleView u_concs(SD.concs, SD.length_concs);
+        SD.d_concs = new DoubleView(Kokkos::ViewAllocateWithoutInitializing("d_concs"), SD.length_concs);
+        Kokkos::deep_copy(*SD.d_concs, u_concs);
+
+        UIntView u_mats(SD.mats, SD.length_mats);
+        SD.d_mats = new IntView(Kokkos::ViewAllocateWithoutInitializing("d_mats"), SD.length_mats);
+        Kokkos::deep_copy(*SD.d_mats, u_mats);
+
+        if (SD.length_unionized_energy_array > 0) {
+                UDoubleView u_unionized_energy_array(SD.unionized_energy_array, SD.length_unionized_energy_array);
+                SD.d_unionized_energy_array = new DoubleView(Kokkos::ViewAllocateWithoutInitializing("d_unionized_energy_array"),
+                                                             SD.length_unionized_energy_array);
+                Kokkos::deep_copy(*SD.d_unionized_energy_array, u_unionized_energy_array);
+        }
+
+        if (SD.length_index_grid > 0) {
+                UIntView u_index_grid(SD.index_grid, SD.length_index_grid);
+                SD.d_index_grid = new IntView(Kokkos::ViewAllocateWithoutInitializing("d_index_grid"), SD.length_index_grid);
+                Kokkos::deep_copy(*SD.d_index_grid, u_index_grid);
+        }
+
+        UPointView u_nuclide_grid(SD.nuclide_grid, SD.length_nuclide_grid);
+        SD.d_nuclide_grid = new PointView(Kokkos::ViewAllocateWithoutInitializing("d_nuclide_grid"), SD.length_nuclide_grid);
+        Kokkos::deep_copy(*SD.d_nuclide_grid, u_nuclide_grid);
+
+	IntView num_nucs(*SD.d_num_nucs);
+	DoubleView concs(*SD.d_concs);
+	IntView mats(*SD.d_mats);
+	DoubleView unionized_energy_array;
+  IntView index_grid;
+  if (SD.length_unionized_energy_array > 0)
+	  unionized_energy_array= *SD.d_unionized_energy_array;
+  if (SD.length_index_grid > 0)
+	  index_grid= *SD.d_index_grid;
+	PointView nuclide_grid(*SD.d_nuclide_grid);
+
+	////////////////////////////////////////////////////////////////////////////////
+	// Begin Actual Simulation Loop
+	////////////////////////////////////////////////////////////////////////////////
+	//unsigned long long * verification = (unsigned long long *) malloc(in.lookups * sizeof(unsigned long long));
+	Kokkos::View<unsigned long long*> d_verification("d_ver", in.lookups);
+	Kokkos::View<unsigned long long*>::HostMirror verification =
+			Kokkos::create_mirror_view(d_verification);
+	Kokkos::deep_copy(d_verification, verification);
+
+	profile->host_to_device_time = get_time() - startP;
+
+	int nwarmups = in.num_warmups;
+	for (int it = 0; it < in.num_iterations + nwarmups; it++) {
+		if (it == nwarmups) {
+			Kokkos::fence();
+			startP = get_time();
+		}
+		Kokkos::parallel_for("Simulation",
+				     Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace>(0, in.lookups),
+				     KOKKOS_LAMBDA (int i) {
+			// Set the initial seed value
+			uint64_t seed = STARTING_SEED;
+
+			// Forward seed to lookup index (we need 2 samples per lookup)
+			seed = fast_forward_LCG(seed, 2*i);
+
+			// Randomly pick an energy and material for the particle
+			double p_energy = LCG_random_double(&seed);
+			int mat         = pick_mat(&seed);
+
+			// debugging
+			//printf("E = %lf mat = %d\n", p_energy, mat);
+
+			double macro_xs_vector[5] = {0};
+
+			// Perform macroscopic Cross Section Lookup
+			calculate_macro_xs(
+					p_energy,        // Sampled neutron energy (in lethargy)
+					mat,             // Sampled material type index neutron is in
+					in.n_isotopes,   // Total number of isotopes in simulation
+					in.n_gridpoints, // Number of gridpoints per isotope in simulation
+					num_nucs,     // 1-D array with number of nuclides per material
+					concs,        // Flattened 2-D array with concentration of each nuclide in each material
+					unionized_energy_array, // 1-D Unionized energy array
+					index_grid,   // Flattened 2-D grid holding indices into nuclide grid for each unionized energy level
+					nuclide_grid, // Flattened 2-D grid holding energy levels and XS_data for all nuclides in simulation
+					mats,         // Flattened 2-D array with nuclide indices defining composition of each type of material
+					macro_xs_vector, // 1-D array with result of the macroscopic cross section (5 different reaction channels)
+					in.grid_type,    // Lookup type (nuclide, hash, or unionized)
+					in.hash_bins,    // Number of hash bins used (if using hash lookup type)
+					SD.max_num_nucs  // Maximum number of nuclides present in any material
+			 		);
+
+			// For verification, and to prevent the compiler from optimizing
+			// all work out, we interrogate the returned macro_xs_vector array
+			// to find its maximum value index, then increment the verification
+			// value by that index. In this implementation, we prevent thread
+			// contention by using an OMP reduction on the verification value.
+			// For accelerators, a different approach might be required
+			// (e.g., atomics, reduction of thread-specific values in large
+			// array via CUDA thrust, etc).
+			double max = -1.0;
+			int max_idx = 0;
+			for(int j = 0; j < 5; j++ )
+			{
+				if( macro_xs_vector[j] > max )
+				{
+					max = macro_xs_vector[j];
+					max_idx = j;
+				}
+			}
+			d_verification(i) = max_idx+1;
+		});
+	}
+
+	Kokkos::fence();
+	profile->kernel_time = get_time() - startP;
+
+	startP = get_time();
+
+	Kokkos::deep_copy(verification, d_verification);
+
+	profile->device_to_host_time = get_time() - startP;
+
+	// End Simulation Timer
+	*end = start.seconds();
+
+	// Reduce validation hash on the host
+	unsigned long long validation_hash = 0;
+	for( int i = 0; i < in.lookups; i++ )
+		validation_hash += verification(i);
+
+	return validation_hash;
+}
+
+// Calculates the microscopic cross section for a given nuclide & energy
+KOKKOS_INLINE_FUNCTION
+void calculate_micro_xs(   double p_energy, int nuc, long n_isotopes,
+			   long n_gridpoints,
+			   DoubleView  egrid, IntView  index_data,
+			   PointView  nuclide_grids,
+			   long idx, double *  xs_vector, int grid_type, int hash_bins ){
+	// Variables
+	double f;
+	NuclideGridPoint * low, * high;
+	long low_i, high_i;
+
+	// If using only the nuclide grid, we must perform a binary search
+	// to find the energy location in this particular nuclide's grid.
+	if( grid_type == NUCLIDE )
+	{
+		// Perform binary search on the Nuclide Grid to find the index
+		idx = grid_search_nuclide( n_gridpoints, p_energy, nuclide_grids, nuc*n_gridpoints, 0, n_gridpoints-1);
+
+		// pull ptr from nuclide grid and check to ensure that
+		// we're not reading off the end of the nuclide's grid
+		if( idx == n_gridpoints - 1 ) {
+			low_i = nuc*n_gridpoints + idx - 1;
+			low = &nuclide_grids(low_i);
+		} else {
+			low_i = nuc*n_gridpoints + idx;
+			low = &nuclide_grids(low_i);
+		}
+	}
+	else if( grid_type == UNIONIZED) // Unionized Energy Grid - we already know the index, no binary search needed.
+	{
+		// pull ptr from energy grid and check to ensure that
+		// we're not reading off the end of the nuclide's grid
+		if( index_data(idx * n_isotopes + nuc) == n_gridpoints - 1 ) {
+			low_i = nuc*n_gridpoints + index_data(idx * n_isotopes + nuc) - 1;
+			low = &nuclide_grids(low_i);
+		} else {
+			low_i = nuc*n_gridpoints + index_data(idx * n_isotopes + nuc);
+			low = &nuclide_grids(low_i);
+		}
+	}
+	else // Hash grid
+	{
+		// load lower bounding index
+		int u_low = index_data(idx * n_isotopes + nuc);
+
+		// Determine higher bounding index
+		int u_high;
+		if( idx == hash_bins - 1 )
+			u_high = n_gridpoints - 1;
+		else
+			u_high = index_data((idx+1)*n_isotopes + nuc) + 1;
+
+		// Check edge cases to make sure energy is actually between these
+		// Then, if things look good, search for gridpoint in the nuclide grid
+		// within the lower and higher limits we've calculated.
+		double e_low  = nuclide_grids(nuc*n_gridpoints + u_low).energy;
+		double e_high = nuclide_grids(nuc*n_gridpoints + u_high).energy;
+		int lower;
+		if( p_energy <= e_low )
+			lower = 0;
+		else if( p_energy >= e_high )
+			lower = n_gridpoints - 1;
+		else
+			lower = grid_search_nuclide( n_gridpoints, p_energy, nuclide_grids, nuc*n_gridpoints, u_low, u_high);
+
+		if( lower == n_gridpoints - 1 ) {
+			low_i = nuc*n_gridpoints + lower - 1;
+			low = &nuclide_grids(low_i);
+		} else {
+			low_i = nuc*n_gridpoints + lower;
+			low = &nuclide_grids(low_i);
+		}
+	}
+
+	high_i = low_i + 1;
+	high = &nuclide_grids(high_i);
+
+	// calculate the re-useable interpolation factor
+	f = (high->energy - p_energy) / (high->energy - low->energy);
+
+	// Total XS
+	xs_vector[0] = high->total_xs - f * (high->total_xs - low->total_xs);
+
+	// Elastic XS
+	xs_vector[1] = high->elastic_xs - f * (high->elastic_xs - low->elastic_xs);
+
+	// Absorbtion XS
+	xs_vector[2] = high->absorbtion_xs - f * (high->absorbtion_xs - low->absorbtion_xs);
+
+	// Fission XS
+	xs_vector[3] = high->fission_xs - f * (high->fission_xs - low->fission_xs);
+
+	// Nu Fission XS
+	xs_vector[4] = high->nu_fission_xs - f * (high->nu_fission_xs - low->nu_fission_xs);
+
+	//test
+	/*
+	if( omp_get_thread_num() == 0 )
+	{
+		printf("Lookup: Energy = %lf, nuc = %d\n", p_energy, nuc);
+		printf("e_h = %lf e_l = %lf\n", high->energy , low->energy);
+		printf("xs_h = %lf xs_l = %lf\n", high->elastic_xs, low->elastic_xs);
+		printf("total_xs = %lf\n\n", xs_vector[1]);
+	}
+	*/
+
+}
+
+// Calculates macroscopic cross section based on a given material & energy
+KOKKOS_INLINE_FUNCTION
+void calculate_macro_xs( double p_energy, int mat, long n_isotopes,
+                         long n_gridpoints, IntView  num_nucs,
+                         DoubleView  concs,
+                         DoubleView  egrid, IntView  index_data,
+                         PointView  nuclide_grids,
+                         IntView  mats,
+                         double *  macro_xs_vector, int grid_type, int hash_bins, int max_num_nucs ){
+	int p_nuc; // the nuclide we are looking up
+	long idx = -1;
+	double conc; // the concentration of the nuclide in the material
+
+	// cleans out macro_xs_vector
+	for( int k = 0; k < 5; k++ )
+		macro_xs_vector[k] = 0;
+
+	// If we are using the unionized energy grid (UEG), we only
+	// need to perform 1 binary search per macroscopic lookup.
+	// If we are using the nuclide grid search, it will have to be
+	// done inside of the "calculate_micro_xs" function for each different
+	// nuclide in the material.
+	if( grid_type == UNIONIZED )
+		idx = grid_search( n_isotopes * n_gridpoints, p_energy, egrid, 0);
+	else if( grid_type == HASH )
+	{
+		double du = 1.0 / hash_bins;
+		idx = p_energy / du;
+	}
+
+	// Once we find the pointer array on the UEG, we can pull the data
+	// from the respective nuclide grids, as well as the nuclide
+	// concentration data for the material
+	// Each nuclide from the material needs to have its micro-XS array
+	// looked up & interpolatied (via calculate_micro_xs). Then, the
+	// micro XS is multiplied by the concentration of that nuclide
+	// in the material, and added to the total macro XS array.
+	// (Independent -- though if parallelizing, must use atomic operations
+	//  or otherwise control access to the xs_vector and macro_xs_vector to
+	//  avoid simulataneous writing to the same data structure)
+	for( int j = 0; j < num_nucs(mat); j++ )
+	{
+		double xs_vector[5];
+		p_nuc = mats(mat*max_num_nucs + j);
+		conc = concs(mat*max_num_nucs + j);
+		calculate_micro_xs( p_energy, p_nuc, n_isotopes,
+		                    n_gridpoints, egrid, index_data,
+		                    nuclide_grids, idx, xs_vector, grid_type, hash_bins );
+		for( int k = 0; k < 5; k++ )
+			macro_xs_vector[k] += xs_vector[k] * conc;
+	}
+
+	//test
+	/*
+	for( int k = 0; k < 5; k++ )
+		printf("Energy: %lf, Material: %d, XSVector[%d]: %lf\n",
+		       p_energy, mat, k, macro_xs_vector[k]);
+			   */
+}
+
+
+// binary search for energy on unionized energy grid
+// returns lower index
+KOKKOS_INLINE_FUNCTION
+long grid_search( long n, double quarry, DoubleView A, long off)
+{
+	long lowerLimit = 0;
+	long upperLimit = n-1;
+	long examinationPoint;
+	long length = upperLimit - lowerLimit;
+
+	while( length > 1 )
+	{
+		examinationPoint = lowerLimit + ( length / 2 );
+
+		if( A(examinationPoint + off) > quarry )
+			upperLimit = examinationPoint;
+		else
+			lowerLimit = examinationPoint;
+
+		length = upperLimit - lowerLimit;
+	}
+
+	return lowerLimit;
+}
+
+// binary search for energy on nuclide energy grid
+KOKKOS_INLINE_FUNCTION
+long grid_search_nuclide( long n, double quarry, PointView A, long off, long low, long high)
+{
+	long lowerLimit = low;
+	long upperLimit = high;
+	long examinationPoint;
+	long length = upperLimit - lowerLimit;
+
+	while( length > 1 )
+	{
+		examinationPoint = lowerLimit + ( length / 2 );
+
+		if( A(examinationPoint + off).energy > quarry )
+			upperLimit = examinationPoint;
+		else
+			lowerLimit = examinationPoint;
+
+		length = upperLimit - lowerLimit;
+	}
+
+	return lowerLimit;
+}
+
+long grid_search_nuclide_old( long n, double quarry, NuclideGridPoint* A, long low, long high)
+{
+	long lowerLimit = low;
+	long upperLimit = high;
+	long examinationPoint;
+	long length = upperLimit - lowerLimit;
+
+	while( length > 1 )
+	{
+		examinationPoint = lowerLimit + ( length / 2 );
+
+		if( A[examinationPoint].energy > quarry )
+			upperLimit = examinationPoint;
+		else
+			lowerLimit = examinationPoint;
+
+		length = upperLimit - lowerLimit;
+	}
+
+	return lowerLimit;
+}
+
+
+// picks a material based on a probabilistic distribution
+KOKKOS_INLINE_FUNCTION
+int pick_mat( uint64_t * seed )
+{
+	// I have a nice spreadsheet supporting these numbers. They are
+	// the fractions (by volume) of material in the core. Not a
+	// *perfect* approximation of where XS lookups are going to occur,
+	// but this will do a good job of biasing the system nonetheless.
+
+	// Also could be argued that doing fractions by weight would be
+	// a better approximation, but volume does a good enough job for now.
+
+	double dist[12];
+	dist[0]  = 0.140;	// fuel
+	dist[1]  = 0.052;	// cladding
+	dist[2]  = 0.275;	// cold, borated water
+	dist[3]  = 0.134;	// hot, borated water
+	dist[4]  = 0.154;	// RPV
+	dist[5]  = 0.064;	// Lower, radial reflector
+	dist[6]  = 0.066;	// Upper reflector / top plate
+	dist[7]  = 0.055;	// bottom plate
+	dist[8]  = 0.008;	// bottom nozzle
+	dist[9]  = 0.015;	// top nozzle
+	dist[10] = 0.025;	// top of fuel assemblies
+	dist[11] = 0.013;	// bottom of fuel assemblies
+
+	double roll = LCG_random_double(seed);
+
+	// makes a pick based on the distro
+	for( int i = 0; i < 12; i++ )
+	{
+		double running = 0;
+		for( int j = i; j > 0; j-- )
+			running += dist[j];
+		if( roll < running )
+			return i;
+	}
+
+	return 0;
+}
+
+// This won't compile if this is inline for some reason
+KOKKOS_FUNCTION
+double LCG_random_double(uint64_t * seed)
+{
+	// LCG parameters
+	const uint64_t m = 9223372036854775808ULL; // 2^63
+	const uint64_t a = 2806196910506780709ULL;
+	const uint64_t c = 1ULL;
+	*seed = (a * (*seed) + c) % m;
+	return (double) (*seed) / (double) m;
+	//return ldexp(*seed, -63);
+
+}
+
+KOKKOS_INLINE_FUNCTION
+uint64_t fast_forward_LCG(uint64_t seed, uint64_t n)
+{
+	// LCG parameters
+	const uint64_t m = 9223372036854775808ULL; // 2^63
+	uint64_t a = 2806196910506780709ULL;
+	uint64_t c = 1ULL;
+
+	n = n % m;
+
+	uint64_t a_new = 1;
+	uint64_t c_new = 0;
+
+	while(n > 0)
+	{
+		if(n & 1)
+		{
+			a_new *= a;
+			c_new = c_new * a + c;
+		}
+		c *= (a + 1);
+		a *= a;
+
+		n >>= 1;
+	}
+
+	return (a_new * seed + c_new) % m;
+
+}

--- a/targets/XSBench/kokkos/XSbench_header.hpp
+++ b/targets/XSBench/kokkos/XSbench_header.hpp
@@ -1,0 +1,142 @@
+#ifndef __XSBENCH_HEADER_H__
+#define __XSBENCH_HEADER_H__
+
+#include<stdio.h>
+#include<stdlib.h>
+#include<string.h>
+#include<strings.h>
+#include<math.h>
+#include<omp.h>
+#include<unistd.h>
+#include<chrono>
+#include<assert.h>
+#include<stdint.h>
+#include "../XSbench_shared_header.h"
+
+#include <Kokkos_Core.hpp>
+
+// Papi Header
+#ifdef PAPI
+#include "papi.h"
+#endif
+
+// Grid types
+#define UNIONIZED 0
+#define NUCLIDE 1
+#define HASH 2
+
+// Simulation types
+#define HISTORY_BASED 1
+#define EVENT_BASED 2
+
+// Binary Mode Type
+#define NONE 0
+#define READ 1
+#define WRITE 2
+
+// Starting Seed
+#define STARTING_SEED 1070
+
+// Structures
+typedef struct{
+	double energy;
+	double total_xs;
+	double elastic_xs;
+	double absorbtion_xs;
+	double fission_xs;
+	double nu_fission_xs;
+} NuclideGridPoint;
+
+typedef Kokkos::View<int*> IntView;
+typedef Kokkos::View<double*> DoubleView;
+typedef Kokkos::View<NuclideGridPoint*> PointView;
+typedef Kokkos::View<int*, Kokkos::LayoutLeft, Kokkos::HostSpace,
+		     Kokkos::MemoryTraits<Kokkos::Unmanaged>> UIntView;
+typedef Kokkos::View<double*, Kokkos::LayoutLeft, Kokkos::HostSpace,
+		     Kokkos::MemoryTraits<Kokkos::Unmanaged>> UDoubleView;
+typedef Kokkos::View<NuclideGridPoint*, Kokkos::LayoutLeft, Kokkos::HostSpace,
+		     Kokkos::MemoryTraits<Kokkos::Unmanaged>> UPointView;
+
+typedef struct{
+	IntView* d_num_nucs;				// Length = length_num_nucs;
+	DoubleView* d_concs;				// Length = length_concs
+	IntView* d_mats;				// Length = length_mats
+	DoubleView* d_unionized_energy_array;		// Length = length_unionized_energy_array
+	IntView* d_index_grid;				// Length = length_index_grid
+	PointView* d_nuclide_grid;			// Length = length_nuclide_grid
+	int * num_nucs;
+	double * concs;
+	int * mats;
+	double * unionized_energy_array;
+	int * index_grid;
+	NuclideGridPoint * nuclide_grid;
+	int length_num_nucs;
+	int length_concs;
+	int length_mats;
+	int length_unionized_energy_array;
+	long length_index_grid;
+	int length_nuclide_grid;
+	IntView* d_max_num_nucs;
+	int max_num_nucs;
+	double * p_energy_samples;
+	int length_p_energy_samples;
+	int * mat_samples;
+	int length_mat_samples;
+} SimulationData;
+
+// io.c
+void logo(int version);
+void center_print(const char *s, int width);
+void border_print(void);
+void fancy_int(long a);
+Inputs read_CLI( int argc, char * argv[] );
+void print_CLI_error(void);
+void print_inputs(Inputs in, int nprocs, int version);
+int print_results( Inputs in, int mype, double runtime, int nprocs, unsigned long long vhash );
+void binary_write( Inputs in, SimulationData SD );
+SimulationData binary_read( Inputs in );
+
+// Simulation.c
+unsigned long long run_event_based_simulation(Inputs in, SimulationData SD, int mype, double* end, Profile* profile);
+unsigned long long run_history_based_simulation(Inputs in, SimulationData SD, int mype);
+KOKKOS_INLINE_FUNCTION
+void calculate_micro_xs(   double p_energy, int nuc, long n_isotopes,
+			   long n_gridpoints,
+			   DoubleView  egrid, IntView  index_data,
+			   PointView *  nuclide_grids,
+			   long idx, double *  xs_vector, int grid_type, int hash_bins );
+KOKKOS_INLINE_FUNCTION
+void calculate_macro_xs( double p_energy, int mat, long n_isotopes,
+                         long n_gridpoints, IntView  num_nucs,
+                         DoubleView  concs,
+                         DoubleView  egrid, IntView  index_data,
+                         PointView  nuclide_grids,
+                         IntView  mats,
+                         double *  macro_xs_vector, int grid_type, int hash_bins, int max_num_nucs );
+KOKKOS_INLINE_FUNCTION
+long grid_search( long n, double quarry, DoubleView A, long off);
+KOKKOS_INLINE_FUNCTION
+long grid_search_nuclide( long n, double quarry, PointView A, long off, long low, long high);
+long grid_search_nuclide_old( long n, double quarry, NuclideGridPoint* A, long low, long high);
+KOKKOS_INLINE_FUNCTION
+int pick_mat( uint64_t * seed );
+KOKKOS_FUNCTION
+double LCG_random_double(uint64_t * seed);
+KOKKOS_INLINE_FUNCTION
+uint64_t fast_forward_LCG(uint64_t seed, uint64_t n);
+unsigned long long run_event_based_simulation_optimization_1(Inputs in, SimulationData SD, int mype);
+
+// GridInit.c
+SimulationData grid_init_do_not_profile( Inputs in, int mype );
+
+// XSutils.c
+int NGP_compare( const void * a, const void * b );
+int double_compare(const void * a, const void * b);
+size_t estimate_mem_usage( Inputs in );
+double get_time(void);
+
+// Materials.c
+int * load_num_nucs(long n_isotopes);
+int * load_mats( int * num_nucs, long n_isotopes, int * max_num_nucs );
+double * load_concs( int * num_nucs, int max_num_nucs );
+#endif

--- a/targets/XSBench/kokkos/XSutils.cpp
+++ b/targets/XSBench/kokkos/XSutils.cpp
@@ -1,0 +1,58 @@
+#include "XSbench_header.hpp"
+
+int double_compare(const void * a, const void * b)
+{
+	double A = *((double *) a);
+	double B = *((double *) b);
+
+	if( A > B )
+		return 1;
+	else if( A < B )
+		return -1;
+	else
+		return 0;
+}
+
+int NGP_compare(const void * a, const void * b)
+{
+	NuclideGridPoint A = *((NuclideGridPoint *) a);
+	NuclideGridPoint B = *((NuclideGridPoint *) b);
+
+	if( A.energy > B.energy )
+		return 1;
+	else if( A.energy < B.energy )
+		return -1;
+	else
+		return 0;
+}
+
+
+size_t estimate_mem_usage( Inputs in )
+{
+	size_t single_nuclide_grid = in.n_gridpoints * sizeof( NuclideGridPoint );
+	size_t all_nuclide_grids   = in.n_isotopes * single_nuclide_grid;
+	size_t size_UEG            = in.n_isotopes*in.n_gridpoints*sizeof(double) + in.n_isotopes*in.n_gridpoints*in.n_isotopes*sizeof(int);
+	size_t size_hash_grid      = in.hash_bins * in.n_isotopes * sizeof(int);
+	size_t memtotal;
+
+	if( in.grid_type == UNIONIZED )
+		memtotal          = all_nuclide_grids + size_UEG;
+	else if( in.grid_type == NUCLIDE )
+		memtotal          = all_nuclide_grids;
+	else
+		memtotal          = all_nuclide_grids + size_hash_grid;
+
+	memtotal          = ceil(memtotal / (1024.0*1024.0));
+	return memtotal;
+}
+
+double get_time(void)
+{
+#ifdef MPI
+	return MPI_Wtime();
+#endif
+
+	// If using C++, we can do this:
+	unsigned long us_since_epoch = std::chrono::high_resolution_clock::now().time_since_epoch() / std::chrono::microseconds(1);
+	return (double) us_since_epoch / 1.0e6;
+}

--- a/targets/XSBench/kokkos/io.cpp
+++ b/targets/XSBench/kokkos/io.cpp
@@ -1,0 +1,537 @@
+#include "XSbench_header.hpp"
+
+#ifdef MPI
+#include<mpi.h>
+#endif
+
+// Prints program logo
+void logo(int version)
+{
+	border_print();
+	printf(
+	"                   __   __ ___________                 _                        \n"
+	"                   \\ \\ / //  ___| ___ \\               | |                       \n"
+	"                    \\ V / \\ `--.| |_/ / ___ _ __   ___| |__                     \n"
+	"                    /   \\  `--. \\ ___ \\/ _ \\ '_ \\ / __| '_ \\                    \n"
+	"                   / /^\\ \\/\\__/ / |_/ /  __/ | | | (__| | | |                   \n"
+	"                   \\/   \\/\\____/\\____/ \\___|_| |_|\\___|_| |_|                   \n\n"
+    );
+	border_print();
+	center_print("Developed at Argonne National Laboratory", 79);
+	char v[100];
+	sprintf(v, "Version: %d", version);
+	center_print(v, 79);
+	border_print();
+}
+
+// Prints Section titles in center of 80 char terminal
+void center_print(const char *s, int width)
+{
+	int length = strlen(s);
+	int i;
+	for (i=0; i<=(width-length)/2; i++) {
+		fputs(" ", stdout);
+	}
+	fputs(s, stdout);
+	fputs("\n", stdout);
+}
+
+int print_results( Inputs in, int mype, double runtime, int nprocs,
+	unsigned long long vhash )
+{
+	// Calculate Lookups per sec
+	int lookups = 0;
+	if( in.simulation_method == HISTORY_BASED )
+		lookups = in.lookups * in.particles;
+	else if( in.simulation_method == EVENT_BASED )
+		lookups = in.lookups;
+	int lookups_per_sec = (int) ((double) lookups / runtime);
+
+	// If running in MPI, reduce timing statistics and calculate average
+	#ifdef MPI
+	int total_lookups = 0;
+	MPI_Barrier(MPI_COMM_WORLD);
+	MPI_Reduce(&lookups_per_sec, &total_lookups, 1, MPI_INT,
+		   MPI_SUM, 0, MPI_COMM_WORLD);
+	#endif
+
+	int is_invalid_result = 1;
+
+	// Print output
+	if( mype == 0 )
+	{
+		border_print();
+		center_print("RESULTS", 79);
+		border_print();
+
+		// Print the results
+    printf("NOTE: Timings are estimated -- use nvprof/nsys/iprof/rocprof for formal analysis\n");
+		#ifdef MPI
+		printf("MPI ranks:   %d\n", nprocs);
+		#endif
+		#ifdef MPI
+		printf("Total Lookups/s:            ");
+		fancy_int(total_lookups);
+		printf("Avg Lookups/s per MPI rank: ");
+		fancy_int(total_lookups / nprocs);
+		#else
+		printf("Runtime:     %.3lf seconds\n", runtime);
+		printf("Lookups:     "); fancy_int(lookups);
+		printf("Lookups/s:   ");
+		fancy_int(lookups_per_sec);
+		#endif
+	}
+
+	unsigned long long large = 0;
+	unsigned long long small = 0;
+	if( in.simulation_method == EVENT_BASED )
+	{
+		small = 945990;
+		large = 952131;
+	}
+	else if( in.simulation_method == HISTORY_BASED )
+	{
+		small = 941535;
+		large = 954318;
+	}
+	if( strcmp(in.HM, "large") == 0 )
+	{
+		if( vhash == large )
+			is_invalid_result = 0;
+	}
+	else if( strcmp(in.HM, "small") == 0 )
+	{
+		if( vhash == small )
+			is_invalid_result = 0;
+	}
+
+	if(mype == 0 )
+	{
+		if( is_invalid_result )
+			printf("Verification checksum: %llu (WARNING - INAVALID CHECKSUM!)\n", vhash);
+		else
+			printf("Verification checksum: %llu (Valid)\n", vhash);
+		border_print();
+	}
+
+	return is_invalid_result;
+}
+
+void print_inputs(Inputs in, int nprocs, int version )
+{
+	// Calculate Estimate of Memory Usage
+	int mem_tot = estimate_mem_usage( in );
+	logo(version);
+	center_print("INPUT SUMMARY", 79);
+	border_print();
+	printf("Programming Model:            Kokkos\n");
+	if( in.simulation_method == EVENT_BASED )
+		printf("Simulation Method:            Event Based\n");
+	else
+		printf("Simulation Method:            History Based\n");
+	if( in.grid_type == NUCLIDE )
+		printf("Grid Type:                    Nuclide Grid\n");
+	else if( in.grid_type == UNIONIZED )
+		printf("Grid Type:                    Unionized Grid\n");
+	else
+		printf("Grid Type:                    Hash\n");
+
+	printf("Materials:                    %d\n", 12);
+	printf("H-M Benchmark Size:           %s\n", in.HM);
+	printf("Total Nuclides:               %ld\n", in.n_isotopes);
+	printf("Gridpoints (per Nuclide):     ");
+	fancy_int(in.n_gridpoints);
+	if( in.grid_type == HASH )
+	{
+		printf("Hash Bins:                    ");
+		fancy_int(in.hash_bins);
+	}
+	if( in.grid_type == UNIONIZED )
+	{
+		printf("Unionized Energy Gridpoints:  ");
+		fancy_int(in.n_isotopes*in.n_gridpoints);
+	}
+	if( in.simulation_method == HISTORY_BASED )
+	{
+		printf("Particle Histories:           "); fancy_int(in.particles);
+		printf("XS Lookups per Particle:      "); fancy_int(in.lookups);
+	}
+	printf("Total XS Lookups:             "); fancy_int(in.lookups);
+	printf("Total XS Iterations:          "); fancy_int(in.num_iterations);
+	#ifdef MPI
+	printf("MPI Ranks:                    %d\n", nprocs);
+	printf("Mem Usage per MPI Rank (MB):  "); fancy_int(mem_tot);
+	#else
+	printf("Est. Memory Usage (MB):       "); fancy_int(mem_tot);
+	#endif
+	printf("Binary File Mode:             ");
+	if( in.binary_mode == NONE )
+		printf("Off\n");
+	else if( in.binary_mode == READ)
+		printf("Read\n");
+	else
+		printf("Write\n");
+	border_print();
+	center_print("INITIALIZATION - DO NOT PROFILE", 79);
+	border_print();
+}
+
+void border_print(void)
+{
+	printf(
+	"==================================================================="
+	"=============\n");
+}
+
+// Prints comma separated integers - for ease of reading
+void fancy_int( long a )
+{
+    if( a < 1000 )
+	printf("%ld\n",a);
+
+    else if( a >= 1000 && a < 1000000 )
+	printf("%ld,%03ld\n", a / 1000, a % 1000);
+
+    else if( a >= 1000000 && a < 1000000000 )
+	printf("%ld,%03ld,%03ld\n",a / 1000000,(a % 1000000) / 1000,a % 1000 );
+
+    else if( a >= 1000000000 )
+	printf("%ld,%03ld,%03ld,%03ld\n",
+	       a / 1000000000,
+	       (a % 1000000000) / 1000000,
+	       (a % 1000000) / 1000,
+	       a % 1000 );
+    else
+	printf("%ld\n",a);
+}
+
+void print_CLI_error(void)
+{
+	printf("Usage: ./XSBench <options>\n");
+	printf("Options include:\n");
+	printf("  -m <simulation method>   Simulation method (history, event)\n");
+	printf("  -s <size>                Size of H-M Benchmark to run (small, large, XL, XXL)\n");
+	printf("  -g <gridpoints>          Number of gridpoints per nuclide (overrides -s defaults)\n");
+	printf("  -G <grid type>           Grid search type (unionized, nuclide, hash). Defaults to unionized.\n");
+	printf("  -p <particles>           Number of particle histories\n");
+	printf("  -l <lookups>             History Based: Number of Cross-section (XS) lookups per particle. Event Based: Total number of XS lookups.\n");
+	printf("  -h <hash bins>           Number of hash bins (only relevant when used with \"-G hash\")\n");
+	printf("  -b <binary mode>         Read or write all data structures to file. If reading, this will skip initialization phase. (read, write)\n");
+	printf("  -k <kernel ID>           Specifies which kernel to run. 0 is baseline, 1, 2, etc are optimized variants. (0 is default.)\n");
+	printf("  -n <num. iterations>     Specifies how many kernel iterations to run. (1 is default.)\n");
+	printf("Default is equivalent to: -m history -s large -l 34 -p 500000 -G unionized -n 1\n");
+	printf("See readme for full description of default run values\n");
+	exit(4);
+}
+
+Inputs read_CLI( int argc, char * argv[] )
+{
+	Inputs input;
+
+	// defaults to the history based simulation method
+	input.simulation_method = HISTORY_BASED;
+
+	// defaults to max threads on the system
+	input.nthreads = 1;
+
+	// defaults to 355 (corresponding to H-M Large benchmark)
+	input.n_isotopes = 355;
+
+	// defaults to 11303 (corresponding to H-M Large benchmark)
+	input.n_gridpoints = 11303;
+
+	// defaults to 500,000
+	input.particles = 500000;
+
+	// defaults to 34
+	input.lookups = 34;
+
+	// default to unionized grid
+	input.grid_type = UNIONIZED;
+
+	// default to unionized grid
+	input.hash_bins = 10000;
+
+	// default to no binary read/write
+	input.binary_mode = NONE;
+
+	// defaults to baseline kernel
+	input.kernel_id = 0;
+
+	// defaults to one kernel iteration
+	input.num_iterations = 1;
+
+	// defaults to H-M Large benchmark
+	input.HM = (char *) malloc( 6 * sizeof(char) );
+	input.HM[0] = 'l' ;
+	input.HM[1] = 'a' ;
+	input.HM[2] = 'r' ;
+	input.HM[3] = 'g' ;
+	input.HM[4] = 'e' ;
+	input.HM[5] = '\0';
+
+	// Check if user sets these
+	int user_g = 0;
+
+	int default_lookups = 1;
+	int default_particles = 1;
+  
+  // default to zero warmup iterations
+	input.num_warmups = 1;
+
+  // default to stdout
+  input.filename = NULL;
+
+	// Collect Raw Input
+	for( int i = 1; i < argc; i++ )
+	{
+		char * arg = argv[i];
+
+		// n_gridpoints (-g)
+		if( strcmp(arg, "-g") == 0 )
+		{
+			if( ++i < argc )
+			{
+				user_g = 1;
+				input.n_gridpoints = atol(argv[i]);
+			}
+			else
+				print_CLI_error();
+		}
+		// Simulation Method (-m)
+		else if( strcmp(arg, "-m") == 0 )
+		{
+			char * sim_type;
+			if( ++i < argc )
+				sim_type = argv[i];
+			else
+				print_CLI_error();
+
+			if( strcmp(sim_type, "history") == 0 )
+				input.simulation_method = HISTORY_BASED;
+			else if( strcmp(sim_type, "event") == 0 )
+			{
+				input.simulation_method = EVENT_BASED;
+				// Also resets default # of lookups
+				if( default_lookups && default_particles )
+				{
+					input.lookups =  input.lookups * input.particles;
+					input.particles = 0;
+				}
+			}
+			else
+				print_CLI_error();
+		}
+		// lookups (-l)
+		else if( strcmp(arg, "-l") == 0 )
+		{
+			if( ++i < argc )
+			{
+				input.lookups = atoi(argv[i]);
+				default_lookups = 0;
+			}
+			else
+				print_CLI_error();
+		}
+		// hash bins (-h)
+		else if( strcmp(arg, "-h") == 0 )
+		{
+			if( ++i < argc )
+				input.hash_bins = atoi(argv[i]);
+			else
+				print_CLI_error();
+		}
+		// particles (-p)
+		else if( strcmp(arg, "-p") == 0 )
+		{
+			if( ++i < argc )
+			{
+				input.particles = atoi(argv[i]);
+				default_particles = 0;
+			}
+			else
+				print_CLI_error();
+		}
+		// HM (-s)
+		else if( strcmp(arg, "-s") == 0 )
+		{
+			if( ++i < argc )
+				input.HM = argv[i];
+			else
+				print_CLI_error();
+		}
+		// grid type (-G)
+		else if( strcmp(arg, "-G") == 0 )
+		{
+			char * grid_type;
+			if( ++i < argc )
+				grid_type = argv[i];
+			else
+				print_CLI_error();
+
+			if( strcmp(grid_type, "unionized") == 0 )
+				input.grid_type = UNIONIZED;
+			else if( strcmp(grid_type, "nuclide") == 0 )
+				input.grid_type = NUCLIDE;
+			else if( strcmp(grid_type, "hash") == 0 )
+				input.grid_type = HASH;
+			else
+				print_CLI_error();
+		}
+		// binary mode (-b)
+		else if( strcmp(arg, "-b") == 0 )
+		{
+			char * binary_mode;
+			if( ++i < argc )
+				binary_mode = argv[i];
+			else
+				print_CLI_error();
+
+			if( strcmp(binary_mode, "read") == 0 )
+				input.binary_mode = READ;
+			else if( strcmp(binary_mode, "write") == 0 )
+				input.binary_mode = WRITE;
+			else
+				print_CLI_error();
+		}
+		// kernel optimization selection (-k)
+		else if( strcmp(arg, "-k") == 0 )
+		{
+			if( ++i < argc )
+			{
+				input.kernel_id = atoi(argv[i]);
+			}
+			else
+				print_CLI_error();
+		}
+		// number of kernel iterations (-n)
+		else if( strcmp(arg, "-n") == 0 )
+		{
+			if( ++i < argc )
+			{
+				input.num_iterations = atoi(argv[i]);
+			}
+			else
+			print_CLI_error();
+		}
+		else if( strcmp(arg, "--csv") == 0 )
+		{
+			if( ++i < argc ) {
+        input.filename = (char *)malloc(strlen(argv[i]) + 1);
+        strcpy(input.filename, argv[i]);
+      }
+			else
+				print_CLI_error();
+    }
+		else if( strcmp(arg, "-w") == 0 )
+		{
+			if( ++i < argc)
+			{
+				input.num_warmups = atoi(argv[i]);
+			}
+			else
+				print_CLI_error();
+		}
+		else
+			print_CLI_error();
+	}
+
+	// Validate Input
+
+	// Validate nthreads
+	if( input.nthreads < 1 )
+		print_CLI_error();
+
+	// Validate n_isotopes
+	if( input.n_isotopes < 1 )
+		print_CLI_error();
+
+	// Validate n_gridpoints
+	if( input.n_gridpoints < 1 )
+		print_CLI_error();
+
+	// Validate lookups
+	if( input.lookups < 1 )
+		print_CLI_error();
+
+	// Validate Hash Bins
+	if( input.hash_bins < 1 )
+		print_CLI_error();
+
+	// Validate number of iterations
+	if( input.num_iterations < 1 )
+		print_CLI_error();
+
+	// Validate HM size
+	if( strcasecmp(input.HM, "small") != 0 &&
+		strcasecmp(input.HM, "large") != 0 &&
+		strcasecmp(input.HM, "XL") != 0 &&
+		strcasecmp(input.HM, "XXL") != 0 )
+		print_CLI_error();
+
+	// Set HM size specific parameters
+	// (defaults to large)
+	if( strcasecmp(input.HM, "small") == 0 )
+		input.n_isotopes = 68;
+	else if( strcasecmp(input.HM, "XL") == 0 && user_g == 0 )
+		input.n_gridpoints = 238847; // sized to make 120 GB XS data
+	else if( strcasecmp(input.HM, "XXL") == 0 && user_g == 0 )
+		input.n_gridpoints = 238847 * 2.1; // 252 GB XS data
+
+	// Return input struct
+	return input;
+}
+
+void binary_write( Inputs in, SimulationData SD )
+{
+	char * fname = "XS_data.dat";
+	printf("Writing all data structures to binary file %s...\n", fname);
+	FILE * fp = fopen(fname, "w");
+
+	// Write SimulationData Object. Include pointers, even though we won't be using them.
+	fwrite(&SD, sizeof(SimulationData), 1, fp);
+
+	// Write heap arrays in SimulationData Object
+	fwrite(SD.num_nucs,       sizeof(int), SD.length_num_nucs, fp);
+	fwrite(SD.concs,          sizeof(double), SD.length_concs, fp);
+	fwrite(SD.mats,           sizeof(int), SD.length_mats, fp);
+	fwrite(SD.nuclide_grid,   sizeof(NuclideGridPoint), SD.length_nuclide_grid, fp);
+	fwrite(SD.index_grid, sizeof(int), SD.length_index_grid, fp);
+	fwrite(SD.unionized_energy_array, sizeof(double), SD.length_unionized_energy_array, fp);
+
+	fclose(fp);
+}
+
+SimulationData binary_read( Inputs in )
+{
+	SimulationData SD;
+
+	char * fname = "XS_data.dat";
+	printf("Reading all data structures from binary file %s...\n", fname);
+
+	FILE * fp = fopen(fname, "r");
+	assert(fp != NULL);
+
+	// Read SimulationData Object. Include pointers, even though we won't be using them.
+	fread(&SD, sizeof(SimulationData), 1, fp);
+
+	// Allocate space for arrays on heap
+	SD.num_nucs = (int *) malloc(SD.length_num_nucs * sizeof(int));
+	SD.concs = (double *) malloc(SD.length_concs * sizeof(double));
+	SD.mats = (int *) malloc(SD.length_mats * sizeof(int));
+	SD.nuclide_grid = (NuclideGridPoint *) malloc(SD.length_nuclide_grid * sizeof(NuclideGridPoint));
+	SD.index_grid = (int *) malloc( SD.length_index_grid * sizeof(int));
+	SD.unionized_energy_array = (double *) malloc( SD.length_unionized_energy_array * sizeof(double));
+
+	// Read heap arrays into SimulationData Object
+	fread(SD.num_nucs,       sizeof(int), SD.length_num_nucs, fp);
+	fread(SD.concs,          sizeof(double), SD.length_concs, fp);
+	fread(SD.mats,           sizeof(int), SD.length_mats, fp);
+	fread(SD.nuclide_grid,   sizeof(NuclideGridPoint), SD.length_nuclide_grid, fp);
+	fread(SD.index_grid, sizeof(int), SD.length_index_grid, fp);
+	fread(SD.unionized_energy_array, sizeof(double), SD.length_unionized_energy_array, fp);
+
+	fclose(fp);
+
+	return SD;
+}

--- a/targets/XSBench/openmp-offload/CMakeLists.txt
+++ b/targets/XSBench/openmp-offload/CMakeLists.txt
@@ -1,0 +1,27 @@
+cmake_minimum_required(VERSION 3.21)
+
+project(
+    XSBench_OpenMP_Offload
+    VERSION 1.0
+    LANGUAGES C
+)
+
+if(NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE Release)
+endif()
+
+set(CMAKE_C_FLAGS "-Wall -Wextra")
+set(CMAKE_C_FLAGS_DEBUG "-g")
+set(CMAKE_C_FLAGS_RELEASE "-O3")
+
+set(SOURCE Main.c io.c Simulation.c GridInit.c XSutils.c Materials.c)
+
+add_executable(XSBench ${SOURCE})
+
+separate_arguments(OFFLOAD_FLAGS)
+target_compile_options(XSBench PUBLIC "$<$<CONFIG:RELEASE>:${OFFLOAD_FLAGS}>")
+target_link_options(XSBench PUBLIC "$<$<CONFIG:RELEASE>:${OFFLOAD_FLAGS}>")
+
+target_link_libraries(XSBench PUBLIC m)
+
+install(TARGETS XSBench DESTINATION bin)

--- a/targets/XSBench/openmp-offload/GridInit.c
+++ b/targets/XSBench/openmp-offload/GridInit.c
@@ -1,0 +1,177 @@
+#include "XSbench_header.h"
+
+SimulationData grid_init_do_not_profile( Inputs in, int mype )
+{
+	// Structure to hold all allocated simuluation data arrays
+	SimulationData SD;
+
+	// Keep track of how much data we're allocating
+	size_t nbytes = 0;
+
+	// Set the initial seed value
+	uint64_t seed = 42;
+
+	////////////////////////////////////////////////////////////////////
+	// Initialize Nuclide Grids
+	////////////////////////////////////////////////////////////////////
+
+	if(mype == 0) printf("Intializing nuclide grids...\n");
+
+	// First, we need to initialize our nuclide grid. This comes in the form
+	// of a flattened 2D array that hold all the information we need to define
+	// the cross sections for all isotopes in the simulation.
+	// The grid is composed of "NuclideGridPoint" structures, which hold the
+	// energy level of the grid point and all associated XS data at that level.
+	// An array of structures (AOS) is used instead of
+	// a structure of arrays, as the grid points themselves are accessed in
+	// a random order, but all cross section interaction channels and the
+	// energy level are read whenever the gridpoint is accessed, meaning the
+	// AOS is more cache efficient.
+
+	// Initialize Nuclide Grid
+	SD.length_nuclide_grid = in.n_isotopes * in.n_gridpoints;
+	SD.nuclide_grid     = (NuclideGridPoint *) malloc( SD.length_nuclide_grid * sizeof(NuclideGridPoint));
+	assert(SD.nuclide_grid != NULL);
+	nbytes += SD.length_nuclide_grid * sizeof(NuclideGridPoint);
+	for( int i = 0; i < SD.length_nuclide_grid; i++ )
+	{
+		SD.nuclide_grid[i].energy        = LCG_random_double(&seed);
+		SD.nuclide_grid[i].total_xs      = LCG_random_double(&seed);
+		SD.nuclide_grid[i].elastic_xs    = LCG_random_double(&seed);
+		SD.nuclide_grid[i].absorbtion_xs = LCG_random_double(&seed);
+		SD.nuclide_grid[i].fission_xs    = LCG_random_double(&seed);
+		SD.nuclide_grid[i].nu_fission_xs = LCG_random_double(&seed);
+	}
+
+	// Sort so that each nuclide has data stored in ascending energy order.
+	for( int i = 0; i < in.n_isotopes; i++ )
+		qsort( &SD.nuclide_grid[i*in.n_gridpoints], in.n_gridpoints, sizeof(NuclideGridPoint), NGP_compare);
+
+	// error debug check
+	/*
+	for( int i = 0; i < in.n_isotopes; i++ )
+	{
+		printf("NUCLIDE %d ==============================\n", i);
+		for( int j = 0; j < in.n_gridpoints; j++ )
+			printf("E%d = %lf\n", j, SD.nuclide_grid[i * in.n_gridpoints + j].energy);
+	}
+	*/
+
+
+	////////////////////////////////////////////////////////////////////
+	// Initialize Acceleration Structure
+	////////////////////////////////////////////////////////////////////
+
+	if( in.grid_type == NUCLIDE )
+	{
+		SD.length_unionized_energy_array = 0;
+		SD.length_index_grid = 0;
+	}
+
+	if( in.grid_type == UNIONIZED )
+	{
+		if(mype == 0) printf("Intializing unionized grid...\n");
+
+		// Allocate space to hold the union of all nuclide energy data
+		SD.length_unionized_energy_array = in.n_isotopes * in.n_gridpoints;
+		SD.unionized_energy_array = (double *) malloc( SD.length_unionized_energy_array * sizeof(double));
+		assert(SD.unionized_energy_array != NULL );
+		nbytes += SD.length_unionized_energy_array * sizeof(double);
+
+		// Copy energy data over from the nuclide energy grid
+		for( int i = 0; i < SD.length_unionized_energy_array; i++ )
+			SD.unionized_energy_array[i] = SD.nuclide_grid[i].energy;
+
+		// Sort unionized energy array
+		qsort( SD.unionized_energy_array, SD.length_unionized_energy_array, sizeof(double), double_compare);
+
+		// Allocate space to hold the acceleration grid indices
+		SD.length_index_grid = SD.length_unionized_energy_array * in.n_isotopes;
+		SD.index_grid = (int *) malloc( SD.length_index_grid * sizeof(int));
+		assert(SD.index_grid != NULL);
+		nbytes += SD.length_index_grid * sizeof(int);
+
+		// Generates the double indexing grid
+		int * idx_low = (int *) calloc( in.n_isotopes, sizeof(int));
+		assert(idx_low != NULL );
+		double * energy_high = (double *) malloc( in.n_isotopes * sizeof(double));
+		assert(energy_high != NULL );
+
+		for( int i = 0; i < in.n_isotopes; i++ )
+			energy_high[i] = SD.nuclide_grid[i * in.n_gridpoints + 1].energy;
+
+		for( long e = 0; e < SD.length_unionized_energy_array; e++ )
+		{
+			double unionized_energy = SD.unionized_energy_array[e];
+			for( long i = 0; i < in.n_isotopes; i++ )
+			{
+				if( unionized_energy < energy_high[i]  )
+					SD.index_grid[e * in.n_isotopes + i] = idx_low[i];
+				else if( idx_low[i] == in.n_gridpoints - 2 )
+					SD.index_grid[e * in.n_isotopes + i] = idx_low[i];
+				else
+				{
+					idx_low[i]++;
+					SD.index_grid[e * in.n_isotopes + i] = idx_low[i];
+					energy_high[i] = SD.nuclide_grid[i * in.n_gridpoints + idx_low[i] + 1].energy;
+				}
+			}
+		}
+
+		free(idx_low);
+		free(energy_high);
+	}
+
+	if( in.grid_type == HASH )
+	{
+		if(mype == 0) printf("Intializing hash grid...\n");
+		SD.length_unionized_energy_array = 0;
+		SD.length_index_grid  = in.hash_bins * in.n_isotopes;
+		SD.index_grid = (int *) malloc( SD.length_index_grid * sizeof(int));
+		assert(SD.index_grid != NULL);
+		nbytes += SD.length_index_grid * sizeof(int);
+
+		double du = 1.0 / in.hash_bins;
+
+		// For each energy level in the hash table
+		#pragma omp parallel for
+		for( long e = 0; e < in.hash_bins; e++ )
+		{
+			double energy = e * du;
+
+			// We need to determine the bounding energy levels for all isotopes
+			for( long i = 0; i < in.n_isotopes; i++ )
+			{
+				SD.index_grid[e * in.n_isotopes + i] = grid_search_nuclide( in.n_gridpoints, energy, SD.nuclide_grid + i * in.n_gridpoints, 0, in.n_gridpoints-1);
+			}
+		}
+	}
+
+	////////////////////////////////////////////////////////////////////
+	// Initialize Materials and Concentrations
+	////////////////////////////////////////////////////////////////////
+	if(mype == 0) printf("Intializing material data...\n");
+
+	// Set the number of nuclides in each material
+	SD.num_nucs  = load_num_nucs(in.n_isotopes);
+	SD.length_num_nucs = 12; // There are always 12 materials in XSBench
+
+	// Intialize the flattened 2D grid of material data. The grid holds
+	// a list of nuclide indices for each of the 12 material types. The
+	// grid is allocated as a full square grid, even though not all
+	// materials have the same number of nuclides.
+	SD.mats = load_mats(SD.num_nucs, in.n_isotopes, &SD.max_num_nucs);
+	SD.length_mats = SD.length_num_nucs * SD.max_num_nucs;
+
+	// Intialize the flattened 2D grid of nuclide concentration data. The grid holds
+	// a list of nuclide concentrations for each of the 12 material types. The
+	// grid is allocated as a full square grid, even though not all
+	// materials have the same number of nuclides.
+	SD.concs = load_concs(SD.num_nucs, SD.max_num_nucs);
+	SD.length_concs = SD.length_mats;
+
+	if(mype == 0) printf("Intialization complete. Allocated %.0lf MB of data.\n", nbytes/1024.0/1024.0 );
+
+	return SD;
+
+}

--- a/targets/XSBench/openmp-offload/Main.c
+++ b/targets/XSBench/openmp-offload/Main.c
@@ -1,0 +1,119 @@
+#include "XSbench_header.h"
+
+#ifdef MPI
+#include<mpi.h>
+#endif
+
+int main( int argc, char* argv[] )
+{
+	// =====================================================================
+	// Initialization & Command Line Read-In
+	// =====================================================================
+	int version = 20;
+	int mype = 0;
+	double omp_start, omp_end;
+	int nprocs = 1;
+	unsigned long long verification;
+
+	#ifdef MPI
+	MPI_Status stat;
+	MPI_Init(&argc, &argv);
+	MPI_Comm_size(MPI_COMM_WORLD, &nprocs);
+	MPI_Comm_rank(MPI_COMM_WORLD, &mype);
+	#endif
+
+	// Process CLI Fields -- store in "Inputs" structure
+	Inputs in = read_CLI( argc, argv );
+
+	// Set number of OpenMP Threads
+	//omp_set_num_threads(in.nthreads);
+
+	// Print-out of Input Summary
+	if( mype == 0 )
+		print_inputs( in, nprocs, version );
+
+	// =====================================================================
+	// Prepare Nuclide Energy Grids, Unionized Energy Grid, & Material Data
+	// This is not reflective of a real Monte Carlo simulation workload,
+	// therefore, do not profile this region!
+	// =====================================================================
+
+	SimulationData SD;
+
+	// If read from file mode is selected, skip initialization and load
+	// all simulation data structures from file instead
+	if( in.binary_mode == READ )
+		SD = binary_read(in);
+	else
+		SD = grid_init_do_not_profile( in, mype );
+
+	// If writing from file mode is selected, write all simulation data
+	// structures to file
+	if( in.binary_mode == WRITE && mype == 0 )
+		binary_write(in, SD);
+
+
+	// =====================================================================
+	// Cross Section (XS) Parallel Lookup Simulation
+	// This is the section that should be profiled, as it reflects a
+	// realistic continuous energy Monte Carlo macroscopic cross section
+	// lookup kernel.
+	// =====================================================================
+
+	if( mype == 0 )
+	{
+		printf("\n");
+		border_print();
+		center_print("SIMULATION", 79);
+		border_print();
+	}
+
+	Profile profile;
+
+	// Start Simulation Timer
+	omp_start = omp_get_wtime();
+
+	// Run simulation
+	if( in.simulation_method == EVENT_BASED )
+	{
+		if( in.kernel_id == 0 )
+			verification = run_event_based_simulation(in, SD, mype, &profile);
+		else
+		{
+			printf("Error: No kernel ID %d found!\n", in.kernel_id);
+			exit(1);
+		}
+	}
+	else
+	{
+		printf("History-based simulation not implemented in OpenMP offload code. Instead,\nuse the event-based method with \"-m event\" argument.\n");
+		exit(1);
+	}
+
+	if( mype == 0)
+	{
+		printf("\n" );
+		printf("Simulation complete.\n" );
+	}
+
+	// End Simulation Timer
+	omp_end = omp_get_wtime();
+
+	// =====================================================================
+	// Output Results & Finalize
+	// =====================================================================
+
+	// Final Hash Step
+	verification = verification % 999983;
+
+	// Print / Save Results and Exit
+	int is_invalid_result = print_results( in, mype, omp_end-omp_start, nprocs, verification );
+
+	#ifdef MPI
+	MPI_Finalize();
+	#endif
+
+	print_profile(profile, in);
+
+	return is_invalid_result;
+}

--- a/targets/XSBench/openmp-offload/Makefile
+++ b/targets/XSBench/openmp-offload/Makefile
@@ -7,7 +7,6 @@ OPTIMIZE    ?= yes
 DEBUG       ?= no
 PROFILE     ?= no
 MPI         ?= no
-ALIGNED     ?= yes
 CUDA_ARCH   ?= 80
 
 #===============================================================================
@@ -87,11 +86,6 @@ endif
 # Optimization Flags
 ifeq ($(OPTIMIZE),yes)
   CFLAGS += -O3
-endif
-
-# Workload alignment for accurate comparison
-ifeq ($(ALIGNED),yes)
-	CFLAGS += -DALIGNED_WORK
 endif
 
 # MPI

--- a/targets/XSBench/openmp-offload/Makefile
+++ b/targets/XSBench/openmp-offload/Makefile
@@ -1,0 +1,120 @@
+#===============================================================================
+# User Options
+#===============================================================================
+
+COMPILER    ?= llvm
+OPTIMIZE    ?= yes
+DEBUG       ?= no
+PROFILE     ?= no
+MPI         ?= no
+ALIGNED     ?= yes
+CUDA_ARCH   ?= 80
+
+#===============================================================================
+# Program name & source code list
+#===============================================================================
+
+program = XSBench
+
+source = \
+Main.c \
+io.c \
+Simulation.c \
+GridInit.c \
+XSutils.c \
+Materials.c
+
+obj = $(source:.c=.o)
+
+#===============================================================================
+# Sets Flags
+#===============================================================================
+
+# Standard Flags
+CFLAGS := -std=gnu99 -Wall
+
+# Linker Flags
+LDFLAGS = -lm
+
+# Regular gcc Compiler
+ifeq ($(COMPILER),gnu)
+  CC = gcc
+  CFLAGS += -fopenmp -flto
+endif
+
+# Intel Compiler
+ifeq ($(COMPILER),intel)
+  CC = icx
+  CFLAGS += -fiopenmp -fopenmp-targets=spir64 -D__STRICT_ANSI__
+endif
+
+# LLVM Compiler Targeting A100 -- Change SM Level to Target Other GPUs
+ifeq ($(COMPILER),llvm)
+  CC = clang
+  CFLAGS += -fopenmp -fopenmp-targets=nvptx64-nvidia-cuda -Xopenmp-target -march=sm_$(CUDA_ARCH)
+endif
+
+# IBM XL Compiler
+ifeq ($(COMPILER),ibm)
+  CC = xlc_r
+  CFLAGS += -qsmp=omp -qoffload
+endif
+
+# NVIDIA Compiler Targeting A100 -- Change SM Level to Target Other GPUs
+ifeq ($(COMPILER),nvidia)
+  CC = nvc
+  CFLAGS += -mp=gpu -Minfo=mp -gpu=cc$(CUDA_ARCH)
+endif
+
+# AOMP Targeting MI100 -- Change march to Target Other GPUs
+ifeq ($(COMPILER),amd)
+  CC = clang
+  CFLAGS += -fopenmp -fopenmp-targets=amdgcn-amd-amdhsa -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx908
+endif
+
+# Debug Flags
+ifeq ($(DEBUG),yes)
+  CFLAGS += -g
+  LDFLAGS  += -g
+endif
+
+# Profiling Flags
+ifeq ($(PROFILE),yes)
+  CFLAGS += -pg
+  LDFLAGS  += -pg
+endif
+
+# Optimization Flags
+ifeq ($(OPTIMIZE),yes)
+  CFLAGS += -O3
+endif
+
+# Workload alignment for accurate comparison
+ifeq ($(ALIGNED),yes)
+	CFLAGS += -DALIGNED_WORK
+endif
+
+# MPI
+ifeq ($(MPI),yes)
+  CC = mpicc
+  CFLAGS += -DMPI
+endif
+
+#===============================================================================
+# Targets to Build
+#===============================================================================
+
+$(program): $(obj) XSbench_header.h Makefile
+	$(CC) $(CFLAGS) $(obj) -o $@ $(LDFLAGS)
+
+%.o: %.c XSbench_header.h Makefile
+	$(CC) $(CFLAGS) -c $< -o $@
+
+clean:
+	rm -rf $(program) $(obj)
+
+edit:
+	vim -p $(source) XSbench_header.h
+
+run:
+	./$(program)

--- a/targets/XSBench/openmp-offload/Materials.c
+++ b/targets/XSBench/openmp-offload/Materials.c
@@ -1,0 +1,117 @@
+// Material data is hard coded into the functions in this file.
+// Note that there are 12 materials present in H-M (large or small)
+
+#include "XSbench_header.h"
+
+// num_nucs represents the number of nuclides that each material contains
+int * load_num_nucs(long n_isotopes)
+{
+	int * num_nucs = (int*)malloc(12*sizeof(int));
+
+	// Material 0 is a special case (fuel). The H-M small reactor uses
+	// 34 nuclides, while H-M larges uses 300.
+	if( n_isotopes == 68 )
+		num_nucs[0]  = 34; // HM Small is 34, H-M Large is 321
+	else
+		num_nucs[0]  = 321; // HM Small is 34, H-M Large is 321
+
+	num_nucs[1]  = 5;
+	num_nucs[2]  = 4;
+	num_nucs[3]  = 4;
+	num_nucs[4]  = 27;
+	num_nucs[5]  = 21;
+	num_nucs[6]  = 21;
+	num_nucs[7]  = 21;
+	num_nucs[8]  = 21;
+	num_nucs[9]  = 21;
+	num_nucs[10] = 9;
+	num_nucs[11] = 9;
+
+	return num_nucs;
+}
+
+// Assigns an array of nuclide ID's to each material
+int * load_mats( int * num_nucs, long n_isotopes, int * max_num_nucs )
+{
+	*max_num_nucs = 0;
+	int num_mats = 12;
+	for( int m = 0; m < num_mats; m++ )
+	{
+		if( num_nucs[m] > *max_num_nucs )
+			*max_num_nucs = num_nucs[m];
+	}
+	int * mats = (int *) malloc( num_mats * (*max_num_nucs) * sizeof(int) );
+
+	// Small H-M has 34 fuel nuclides
+	int mats0_Sml[] =  { 58, 59, 60, 61, 40, 42, 43, 44, 45, 46, 1, 2, 3, 7,
+			 8, 9, 10, 29, 57, 47, 48, 0, 62, 15, 33, 34, 52, 53,
+			 54, 55, 56, 18, 23, 41 }; //fuel
+	// Large H-M has 300 fuel nuclides
+	int mats0_Lrg[321] =  { 58, 59, 60, 61, 40, 42, 43, 44, 45, 46, 1, 2, 3, 7,
+			 8, 9, 10, 29, 57, 47, 48, 0, 62, 15, 33, 34, 52, 53,
+			 54, 55, 56, 18, 23, 41 }; //fuel
+	for( int i = 0; i < 321-34; i++ )
+		mats0_Lrg[34+i] = 68 + i; // H-M large adds nuclides to fuel only
+
+	// These are the non-fuel materials
+	int mats1[] =  { 63, 64, 65, 66, 67 }; // cladding
+	int mats2[] =  { 24, 41, 4, 5 }; // cold borated water
+	int mats3[] =  { 24, 41, 4, 5 }; // hot borated water
+	int mats4[] =  { 19, 20, 21, 22, 35, 36, 37, 38, 39, 25, 27, 28, 29,
+			 30, 31, 32, 26, 49, 50, 51, 11, 12, 13, 14, 6, 16,
+			 17 }; // RPV
+	int mats5[] =  { 24, 41, 4, 5, 19, 20, 21, 22, 35, 36, 37, 38, 39, 25,
+			 49, 50, 51, 11, 12, 13, 14 }; // lower radial reflector
+	int mats6[] =  { 24, 41, 4, 5, 19, 20, 21, 22, 35, 36, 37, 38, 39, 25,
+			 49, 50, 51, 11, 12, 13, 14 }; // top reflector / plate
+	int mats7[] =  { 24, 41, 4, 5, 19, 20, 21, 22, 35, 36, 37, 38, 39, 25,
+			 49, 50, 51, 11, 12, 13, 14 }; // bottom plate
+	int mats8[] =  { 24, 41, 4, 5, 19, 20, 21, 22, 35, 36, 37, 38, 39, 25,
+			 49, 50, 51, 11, 12, 13, 14 }; // bottom nozzle
+	int mats9[] =  { 24, 41, 4, 5, 19, 20, 21, 22, 35, 36, 37, 38, 39, 25,
+			 49, 50, 51, 11, 12, 13, 14 }; // top nozzle
+	int mats10[] = { 24, 41, 4, 5, 63, 64, 65, 66, 67 }; // top of FA's
+	int mats11[] = { 24, 41, 4, 5, 63, 64, 65, 66, 67 }; // bottom FA's
+
+	// H-M large v small dependency
+	if( n_isotopes == 68 )
+		memcpy( mats,  mats0_Sml,  num_nucs[0]  * sizeof(int) );
+	else
+		memcpy( mats,  mats0_Lrg,  num_nucs[0]  * sizeof(int) );
+
+	// Copy other materials
+	memcpy( mats + *max_num_nucs * 1,  mats1,  num_nucs[1]  * sizeof(int) );
+	memcpy( mats + *max_num_nucs * 2,  mats2,  num_nucs[2]  * sizeof(int) );
+	memcpy( mats + *max_num_nucs * 3,  mats3,  num_nucs[3]  * sizeof(int) );
+	memcpy( mats + *max_num_nucs * 4,  mats4,  num_nucs[4]  * sizeof(int) );
+	memcpy( mats + *max_num_nucs * 5,  mats5,  num_nucs[5]  * sizeof(int) );
+	memcpy( mats + *max_num_nucs * 6,  mats6,  num_nucs[6]  * sizeof(int) );
+	memcpy( mats + *max_num_nucs * 7,  mats7,  num_nucs[7]  * sizeof(int) );
+	memcpy( mats + *max_num_nucs * 8,  mats8,  num_nucs[8]  * sizeof(int) );
+	memcpy( mats + *max_num_nucs * 9,  mats9,  num_nucs[9]  * sizeof(int) );
+	memcpy( mats + *max_num_nucs * 10, mats10, num_nucs[10] * sizeof(int) );
+	memcpy( mats + *max_num_nucs * 11, mats11, num_nucs[11] * sizeof(int) );
+
+
+	return mats;
+}
+
+// Randomizes the concentrations of all nuclides in a variety of materials
+double * load_concs( int * num_nucs, int max_num_nucs )
+{
+	uint64_t seed = STARTING_SEED * STARTING_SEED;
+	double * concs = (double *) malloc( 12 * max_num_nucs * sizeof( double ) );
+
+	for( int i = 0; i < 12; i++ )
+		for( int j = 0; j < num_nucs[i]; j++ )
+			concs[i * max_num_nucs + j] = LCG_random_double(&seed);
+
+	// test
+	/*
+	for( int i = 0; i < 12; i++ )
+		for( int j = 0; j < num_nucs[i]; j++ )
+			printf("concs[%d][%d] = %lf\n", i, j, concs[i][j] );
+	*/
+
+	return concs;
+}

--- a/targets/XSBench/openmp-offload/README.md
+++ b/targets/XSBench/openmp-offload/README.md
@@ -1,0 +1,242 @@
+![XSBench](docs/img/logo.png)
+
+[![Latest Github release](https://img.shields.io/github/release/ANL-CESAR/XSBench.svg)](https://github.com/ANL-CESAR/XSBench/releases/latest)
+[![Build Status](https://travis-ci.com/ANL-CESAR/XSBench.svg?branch=master)](https://travis-ci.com/ANL-CESAR/XSBench)
+[![Published in Annals of Nuclear Energy](https://img.shields.io/badge/Published%20in-Annals%20of%20Nuclear%20Energy-167DA4.svg)](https://www.sciencedirect.com/science/article/pii/S0306454914004332)
+
+XSBench is a mini-app representing a key computational kernel of the Monte Carlo neutron transport algorithm. Specifically, XSBench represents the continuous energy macroscopic neutron cross section lookup kernel. XSBench serves as a lightweight stand-in for full neutron transport applications like [OpenMC](https://github.com/openmc-dev/openmc), and is a useful tool for performance analysis on high performance computing architectures.
+
+## Table of Contents
+
+1. [Compilation](#Compilation)
+2. [Running XSBench / Command Line Interface](#Running-XSBench)
+3. [Feature Discussion](#Feature-Discussion)
+	* [MPI Support](#MPI-Support)
+	* [Verification Support](#Verification-Support)
+	* [Binary File Support](#Binary-File-Support)
+4. [Theory & Algorithms](#Algorithms)
+	* [Transport Simulation Styles](#Transport-Simulation-Styles)
+		- [History-Based Transport](#History-Based-Transport)
+		- [Event-Based Transport](#Event-Based-Transport)
+	* [Cross Section Lookup Methods](#Cross-Section-Lookup-Methods)
+		- [Nuclide Grid](#Nuclide-Grid)
+		- [Unionized Energy Grid](#Unionized-Energy-Grid)
+		- [Logarithmic Hash Grid](#Logarithmic-Hash-Grid)
+5. [Citing XSBench](#Citing-XSBench)
+6. [Development Team](#Development-Team) 
+
+## Selecting A Programming Model
+
+XSBench has been implemented using OpenMP 4.5 (or newer) to map program data to a remote accelerator memory space and run targeted kernels on the accelerator. This method of parallelism could be used for a wide variety of architectures (besides CPUs) that support OpenMP 4.5 targeting. NOTE: The Makefile will need to be adjusted to utilize your OpenMP accelerator compiler.
+
+## Compilation
+
+To compile XSBench with default settings, navigate to your selected source directory and use the following command:
+
+```bash
+make
+```
+ 
+ You can alter compiler settings in the included Makefile. Alternatively, you may specify a compiler via the CC environment variable and then making as normal, e.g.:
+```bash
+export CC=clang
+make
+```
+
+### Debugging, Optimization & Profiling
+
+There are also a number of switches that can be set in the makefile. Here is a sample of the control panel at the top of the makefile:
+
+```make
+OPTIMIZE = yes
+DEBUG    = no
+PROFILE  = no
+MPI      = no
+```
+- Optimization enables the -O3 optimization flag.
+- Debugging enables the -g flag.
+- Profiling enables the -pg flag. When profiling the code, you may
+wish to significantly increase the number of lookups (with the -l
+flag) in order to wash out the initialization phase of the code.
+- MPI enables MPI support in the code.
+
+## Running XSBench
+
+To run XSBench with default settings, use the following command:
+```bash
+./XSBench
+```
+For non-default settings, XSBench supports the following command line options:
+
+| Argument    |Description | Options     | Default
+|-------------|------------|---------------|------------|
+|-m           |Simulation method| history, event| history|
+|-s | Problem Size | small, large, XL, XXL | large|
+|-g | # of gridpoints per nuclide (overrides -s defaults) | integer value| 11,303 |
+-G | Grid search type | unionized, nuclide, hash | unionized |
+-p | # of particle histories (if running using "history" method)| integer value | 500,000 |
+-l | # of Cross-section (XS) lookups. If using history based method, this is lookups per particle history. If using event-based method, this is total lookups. | integer value | (History: 34) (Event: 17,000,000) |
+-h | # of hash bins (only used with hash-based grid search) | integer value | 10,000 |
+-b | Read/Write binary files | read, write |  |
+
+- **-m [simulation method]**
+Sets the simulation method, either "history" or "event". These options represent the history based or event based algorithms respectively. The default is the history based method. These two methods represent different methods of parallelizing the Monte Carlo transport method. In the history based method, the central mode of parallelism is expressed over particles, which each require some number of macroscopic cross sections to be executed in series and in a dependent order. The event based method expresses its parallelism over a large pool of independent macroscopic cross section lookups that can be executed in any order without dependence. They key difference between the two methods is the dependence/independence of the macroscopic cross section loop. See the [Transport Simulation Styles](#Transport-Simulation-Styles) section for more information.
+
+- **-s [size]**
+Sets the size of the Hoogenboom-Martin reactor model. There are four options: 'small', 'large', 'XL', and 'XXL'. By default, the 'large' option is selected. The H-M size corresponds to the number of nuclides present in the fuel region. The small version has 34 fuel nuclides, whereas the large version has 321 fuel nuclides. This significantly slows down the runtime of the program as the data structures are much larger, and more lookups are required whenever a lookup occurs in a fuel material. Note that the program defaults to "Large" if no specification is made. The additional size options, "XL" and "XXL", do not directly correspond to any particular physical model. They are similar to the H-M "large" option, except the number of gridpoints per nuclide has been increased greatly. This creates an extremely large energy grid data structure (XL: 120GB, XXL: 252GB), which is unlikely to fit on a single node, but is useful for experimentation purposes on novel architectures.
+
+- **-g [gridpoints]**
+Sets the number of gridpoints per nuclide. By default, this value is set to 11,303. This corresponds to the average number of actual gridpoints per nuclide in the H-M Large model as run by OpenMC with the actual ACE ENDF cross-section data. Note that this option will override the number of default gridpoints as set by the '-s' option.
+
+- **-G [grid type]**
+Sets the grid search type (unionized, nuclide, hash). Defaults to unionized. The unionized grid is what is typically used in Monte Carlo codes, as it offers the fastest speed. However, the increase in speed comes in a significant increase in memory usage as a union of all the separate nuclide grids must be formed and stored in memory. The "nuclide" mode uses only the basic nuclide grid data, with no unionization. This is slower as a binary search must be performed on every nuclide for each macroscopic XS lookup, rather than only once when using the unionized grid. Finally, the "hash" mode is a newer algorithm now used by many full Monte Carlo codes which offers speed nearly equivalent to the unionized energy grid method, but with only a small fraction of the memory overhead. See the [Cross Section Lookup Methods](#Cross-Section-Lookup-Methods) section for more details.
+
+- **-p [particles]**
+Sets the number of particle histories to simulate. By default, this value is set to 500,000. Users may want to increase this value if they wish to extend the runtime of XSBench, perhaps to produce more reliable performance counter data - as extending the run will decrease the percentage of runtime spent on initialization. Real MC simulations in a full application may use up to several billion particles per generation, so there is great flexibility in this variable.
+
+- **-l [lookups]**
+Sets the number of cross-section (XS) lookups to perform per particle. By default, this value is set to 34, which represents the average number of XS lookups per particle over the course of its lifetime in a light water reactor problem. Users should only alter this value if they are trying to capture the behavior of a different type of reactor (e.g., one with a fast spectrum), where the number of lookups per history may be different.
+
+- **-h [hash bins]**
+Sets the number of hash bins (only relevant when using the hash lookup algorithm, as selected with "-G hash"). Default is 10,000.
+
+- **-b [binary mode]**
+This optional mode can read or write the simulation data structures to disk. Options are ("read" or "write"). This may be useful if it is necessary to minimize the initialization phase of the program, which has a non-trivial runtime. The generated file is named "XS_data.dat" and will be located in the current working directory. The same file name and location will be used when reading. Note that as the file is binary, it may not be portable between compilers and computer systems. NOTE: When running in the "read" mode, you must be running with an identical program configuration as when the file was generated. E.g., if the file was generated with the "-G nuclide" argument, subsequent runs reading from that file must use the same configuration flags.
+
+## Feature Discussion
+
+### MPI Support
+
+While XSBench is primarily used to investigate "on node parallelism" issues, some systems provide power & performance statistics batched in multi-node configurations. To accommodate this, XSBench provides an MPI mode which runs the code on all MPI ranks simultaneously. There is no decomposition across ranks of any kind, and all ranks accomplish the same work. This is a "weak scaling" approach -- for instance, if running the event-based model all MPI ranks will execute 17,000,000 cross section lookups regardless of how many ranks are used. There is only one point of MPI communication (a reduce) at the end, which aggregates the timing statistics and averages them across MPI ranks before printing them out. MPI support can be enabled with the makefile flag "MPI". If you are not using the mpicc wrapper on your system, you may need to alter the makefile to make use of your desired compiler.
+
+### Verification Support
+
+Legacy versions of XSBench had a special "Verification" compiler flag option to enable verification of the results. However, a much more performant and portable verification scheme was developed and is now used for all configurations -- therefore, it is not necessary to compile with or without the verification mode as it is always enabled by default. XSBench generates a hash of the results at the end of the simulation and displays it with the other data once the code has completed executing. This hash can then be verified against hashes that other versions or configurations of the code generate. For instance, running XSBench with 4 threads vs 8 threads (on a machine that supports that configuration) should generate the same hash number. Running on GPU vs CPU should not change the hash number. However, changing the model / run parameters is expected to generate a totally different hash number (i.e., increasing the number of particles, number of gridpoints, etc, will result in different hashes). However, changing the type of lookup performed (e.g., nuclide, unionized, or hash) should result in the same hash being generated. Changing the simulation mode (history or event) will generate different hashes.
+
+### Binary File Support
+
+Instead of initializing the randomized synthetic cross section data structres in XSBench everytime it is run, you may optionally have XSBench generate a data set and write it to file. It can then be read on subsequent runs to speed up initialization. This process is controlled with the "-b (read, write)" command line argument. This feature may be extremely useful for users running on simulators where walltime minimization is critical for logistical purposes, or for users who are doing many sequential runs. Note that identical input parameters (problem size, solution method etc) must be used when reading and writing a binary file. No runtime checks are made to validate that the file correctly corresponds to the selected input parameters.
+
+
+## Algorithms
+
+### Transport Simulation Styles
+
+#### History-Based Transport
+
+The default simulation model used in XSBench is the "history-based" model. In this model, parallelism is expressed over independent particle histories, with each particle being simulated in a serial fashion from birth to death: 
+
+```c
+for each particle do		   // Independent
+	while particle is alive do // Dependent
+		Move particle to collision site
+		Process particle collision
+```
+
+This method of parallelism is very memory efficient, as the total number of particles that must be kept in memory at once is equivalent to the total number of active threads being run in the simulation. However, as there are many different types of collision events, the history-based model means that there is no natural SIMD style parallelism available for work happening between different threads.
+
+#### Event-Based Transport
+
+An alternative simulation model is the "event-based" model. In this model, parallelism is instead expressed over different collision (or "event") types. To facilitate this, all particles in the simulation are stored in memory at once. Each event kernel is executed in parallel on vectors of particles that currently require that event to be executed:
+
+```c
+Get vector of source particles
+while any particles are alive do	     // Dependent
+	for each living particle do          // Independent
+		Move particle to collision site
+	for each living particle do          // Independent
+		Process particle collision
+	Sort/consolidate surviving particles
+```
+This method of parallelism is requires more memory and requires an extra stream compaction kernel to sort and organize the particles periodically to ready them for the different event kernels. The benefit of this model is that kernels can potentially be execute in a SIMD manner and with higher cache efficiency due to the potential to sort particles by material and energy. On CPU architectures, the costs of sorting and buffering particles typically outweigh the benefits of the event-based model, but on accelerator architectures the tradeoff has been found to usually be more favorable.
+
+### Cross Section (XS) Lookup Methods
+
+XSBench represents the macroscopic cross section lookup kernel. This kernel is responsible for adding together microscopic cross section data from all nuclides present in the material the neutron is travelling through, given a certain energy:
+
+<p align="center"> <img src="docs/img/XS_equation.svg" alt="XS_Lookup_EQ" width="500"/> </p>
+
+Macroscopic cross section data is typically required for multiple reaction channels "c", such as the total cross section, fission cross section, etc. This data is typically stored in point-wise data form for each nuclide. There are multiple ways of accessesing this data in an efficient manner which will be discusses in this section.
+
+#### Nuclide Grid
+
+This is the default "naive" method of performing macroscopic XS lookups. XS data is stored for a number of energy levels for each nuclide in the simulation problem. Different nuclides can have a different number of energy levels. For instance, U-238 usually has over 100k energy levels, whereas some other nuclides may only have a few thousand. The "Nuclide Grid" is composed of all nuclides in the problem, with a variable number of data points for each nuclide. Each data point is composed of the energy level and accompanying cross section data for multiple different reaction channels:
+
+<p align="center"> <img src="docs/img/xs_point.png" alt="xs_point" width="300"/> </p>
+
+These XS data points are arranged into the nuclide grid:
+
+<p align="center"> <img src="docs/img/nuclide_grid.png" alt="nuclide_grid" width="350"/> </p>
+
+When assembling a macroscopic cross section data point, we will be accessing and interpolating data from the nuclide grid for a neutron travelling through a given material (composed of some number of nuclides) and at a given energy level. This will involve performing a binary search for each nuclide:
+
+```
+Nuclide_Grid_Search( Energy E, Material M ):
+	macroscopic XS = 0
+	for each nuclide in M do:
+		index = binary search to find E in nuclide grid
+		interpolate data from grid[nuclide, index]
+		macroscopic XS += data
+```
+
+This algorithm requires no extra memory usage beyond the minimum to represent the pointwise cross section data, but also requires that a binary search be run for each nuclide in the material the neutron is travelling through. In the case of depleted fuel, there can be 300+ nuclides, making this option computationally expensive.
+
+#### Unionized Energy Grid
+
+One way of speeding up the nuclide grid search is to form a separate acceleration structure to reduce the number of binary searches that need to be performed. In the Unionized Energy Grid (EUG) method, a second grid is created with columns corresponding to the **union** of all energy levels from the nuclide grid. For each energy level (column) in the unionized grid, each row stores an index corresponding to the closest location in the nuclide grid for each nuclide corresponding that energy level:
+
+<p align="center"> <img src="docs/img/UEG.png" alt="UEG" width="500"/> </p>
+
+A lookup using the UEG therefore requires only one single binary search on the unionized grid, allowing then for fast accesses using the indices stored at that energy level:
+
+```
+Unionized_Grid_Search( Energy E, Material M ):
+	macroscopic XS = 0
+	UEG_index = binary search to find E in unionized grid
+	for each nuclide in M do:
+		index = unionized_grid[nuclide, UEG_index]
+		interpolate data from grid[nuclide, index]
+		macroscopic XS += data
+```
+
+#### Logarithmic Hash Grid
+
+An alternative to the unionized energy grid is the logarithmic hash grid. This method takes in account the fact that while nuclides will be tabulated on grids containing different numbers of energy points, the points within each nuclide's grid will in general be spaced in (roughly) uniform maner in log space . Therefore, the nuclide grid is augmented with a separate acceleration structure similar to the unionized grid. However, the number of columns is capped at some number of bins spaced evenly in log space, with each row therefore corresponding to an approximate location within each nuclide's grid for that energy level. While the unionized grid points exactly to the correct index in the nuclide grid, the logarithmic hash grid points to only an approximate location below the true point -- meaning that a fast binary or iterative search must still be performed over the constrained area (typically only 10 or so elements in size):
+
+```
+Logarithmic_Hash_Grid_Search( Energy E, Material M ):
+	macroscopic XS = 0
+	hash_index = grid_delta * (ln(E) - grid_minimum_energy)
+	for each nuclide in M do:
+		i_low  = unionized_grid[nuclide, hash_index]
+		i_high = unionized_grid[nuclide, hash_index+1]
+		index = binary search in range(i_low, i_high) to find E in nuclide grid
+		interpolate data from grid[nuclide, index]
+		macroscopic XS += data
+```
+
+Compared to the unionized energy grid method, the logarithmic hash method uses far less memory but typically results in competitive performance. More details on this method can be found in the following publication:
+   
+>Forrest B Brown. New hash-based energy lookup algorithm for monte carlo codes. Trans. Am. Nucl. Soc., 111:659–662, 2014. http://permalink.lanl.gov/object/tr?what=info:lanl-repo/lareport/LA-UR-14-27037
+
+## Citing XSBench
+
+Papers citing the XSBench program in general should refer to:
+
+>J. R. Tramm, A. R. Siegel, T. Islam, and M. Schulz, “XSBench - The Development and Verification of a Performance Abstraction for Monte Carlo Reactor Analysis,” presented at PHYSOR 2014 - The Role of Reactor Physics toward a Sustainable Future, Kyoto. https://www.mcs.anl.gov/papers/P5064-0114.pdf
+
+Bibtex Entry:
+
+```bibtex
+@inproceedings{Tramm:wy,
+author = {Tramm, John R and Siegel, Andrew R and Islam, Tanzima and Schulz, Martin},
+title = {{XSBench} - The Development and Verification of a Performance Abstraction for {M}onte {C}arlo Reactor Analysis},
+booktitle = {{PHYSOR} 2014 - The Role of Reactor Physics toward a Sustainable Future},
+address = {Kyoto},
+year = 2014,
+url = "https://www.mcs.anl.gov/papers/P5064-0114.pdf"
+}
+```
+
+## Development Team
+Authored and maintained by John Tramm ([@jtramm](https://github.com/jtramm)) with help from Ron Rahaman, Amanda Lund, and other [contributors](https://github.com/ANL-CESAR/XSBench/graphs/contributors).

--- a/targets/XSBench/openmp-offload/Simulation.c
+++ b/targets/XSBench/openmp-offload/Simulation.c
@@ -1,0 +1,428 @@
+#include "XSbench_header.h"
+
+////////////////////////////////////////////////////////////////////////////////////
+// BASELINE FUNCTIONS
+////////////////////////////////////////////////////////////////////////////////////
+// All "baseline" code is at the top of this file. The baseline code is a simple
+// implementation of the algorithm, with only minor CPU optimizations in place.
+// Following these functions are a number of optimized variants,
+// which each deploy a different combination of optimizations strategies. By
+// default, XSBench will only run the baseline implementation. Optimized variants
+// are not yet implemented for this OpenMP targeting offload port.
+////////////////////////////////////////////////////////////////////////////////////
+
+unsigned long long run_event_based_simulation(Inputs in, SimulationData SD, int mype, Profile* profile)
+{
+	if( mype == 0)
+		printf("Beginning event based simulation...\n");
+
+	////////////////////////////////////////////////////////////////////////////////
+	// SUMMARY: Simulation Data Structure Manifest for "SD" Object
+	// Here we list all heap arrays (and lengths) in SD that would need to be
+	// offloaded manually if using an accelerator with a seperate memory space
+	////////////////////////////////////////////////////////////////////////////////
+	// int * num_nucs;                     // Length = length_num_nucs;
+	// double * concs;                     // Length = length_concs
+	// int * mats;                         // Length = length_mats
+	// double * unionized_energy_array;    // Length = length_unionized_energy_array
+	// int * index_grid;                   // Length = length_index_grid
+	// NuclideGridPoint * nuclide_grid;    // Length = length_nuclide_grid
+	//
+	// Note: "unionized_energy_array" and "index_grid" can be of zero length
+	//        depending on lookup method.
+	//
+	// Note: "Lengths" are given as the number of objects in the array, not the
+	//       number of bytes.
+	////////////////////////////////////////////////////////////////////////////////
+
+
+	////////////////////////////////////////////////////////////////////////////////
+	// Begin Actual Simulation Loop
+	////////////////////////////////////////////////////////////////////////////////
+	unsigned long long * verification = (unsigned long long *) malloc(in.lookups * sizeof(unsigned long long));
+
+	double start = get_time();
+
+	int *num_nucs = SD.num_nucs;
+	double *concs = SD.concs;
+	int *mats = SD.mats;
+	double *unionized_energy_array = SD.unionized_energy_array;
+	int *index_grid = SD.index_grid;
+	NuclideGridPoint *nuclide_grid = SD.nuclide_grid;
+
+	#pragma omp target enter data \
+		map(to: num_nucs[:SD.length_num_nucs], concs[:SD.length_concs], \
+		    mats[:SD.length_mats], nuclide_grid[:SD.length_nuclide_grid]) \
+		map(alloc: verification[:in.lookups])
+
+	if (SD.length_unionized_energy_array > 0) {
+		#pragma omp target enter data map(to: unionized_energy_array[:SD.length_unionized_energy_array])
+	}
+
+	if (SD.length_index_grid > 0) {
+		#pragma omp target enter data map(to: index_grid[:SD.length_index_grid])
+	}
+
+	profile->host_to_device_time = get_time() - start;
+
+	int nwarmups = in.num_warmups;
+	for (int it = 0; it < in.num_iterations + nwarmups; it++) {
+		if (it == nwarmups) start = get_time();
+		#pragma omp target teams distribute parallel for
+		for( int i = 0; i < in.lookups; i++ )
+		{
+			// Set the initial seed value
+			uint64_t seed = STARTING_SEED;
+
+			// Forward seed to lookup index (we need 2 samples per lookup)
+			seed = fast_forward_LCG(seed, 2*i);
+
+			// Randomly pick an energy and material for the particle
+			double p_energy = LCG_random_double(&seed);
+			int mat         = pick_mat(&seed);
+
+			// debugging
+			//printf("E = %lf mat = %d\n", p_energy, mat);
+
+			double macro_xs_vector[5] = {0};
+
+			// Perform macroscopic Cross Section Lookup
+			calculate_macro_xs(
+					p_energy,        // Sampled neutron energy (in lethargy)
+					mat,             // Sampled material type index neutron is in
+					in.n_isotopes,   // Total number of isotopes in simulation
+					in.n_gridpoints, // Number of gridpoints per isotope in simulation
+					num_nucs,     // 1-D array with number of nuclides per material
+					concs,        // Flattened 2-D array with concentration of each nuclide in each material
+					unionized_energy_array, // 1-D Unionized energy array
+					index_grid,   // Flattened 2-D grid holding indices into nuclide grid for each unionized energy level
+					nuclide_grid, // Flattened 2-D grid holding energy levels and XS_data for all nuclides in simulation
+					mats,         // Flattened 2-D array with nuclide indices defining composition of each type of material
+					macro_xs_vector, // 1-D array with result of the macroscopic cross section (5 different reaction channels)
+					in.grid_type,    // Lookup type (nuclide, hash, or unionized)
+					in.hash_bins,    // Number of hash bins used (if using hash lookup type)
+					SD.max_num_nucs  // Maximum number of nuclides present in any material
+					);
+
+			// For verification, and to prevent the compiler from optimizing
+			// all work out, we interrogate the returned macro_xs_vector array
+			// to find its maximum value index, then increment the verification
+			// value by that index. In this implementation, we prevent thread
+			// contention by using an OMP reduction on the verification value.
+			// For accelerators, a different approach might be required
+			// (e.g., atomics, reduction of thread-specific values in large
+			// array via CUDA thrust, etc).
+			double max = -1.0;
+			int max_idx = 0;
+			for(int j = 0; j < 5; j++ )
+			{
+				if( macro_xs_vector[j] > max )
+				{
+					max = macro_xs_vector[j];
+					max_idx = j;
+				}
+			}
+			verification[i] = max_idx+1;
+		}
+	}
+	profile->kernel_time = get_time() - start;
+
+	start = get_time();
+
+	#pragma omp target exit data\
+	map(from: verification[:in.lookups])
+
+	profile->device_to_host_time = get_time() - start;
+
+	// Reduce validation hash on the host
+	unsigned long long validation_hash = 0;
+	for( int i = 0; i < in.lookups; i++ )
+		validation_hash += verification[i];
+
+	return validation_hash;
+}
+
+// Calculates the microscopic cross section for a given nuclide & energy
+void calculate_micro_xs(   double p_energy, int nuc, long n_isotopes,
+                           long n_gridpoints,
+                           double *  egrid, int *  index_data,
+                           NuclideGridPoint *  nuclide_grids,
+                           long idx, double *  xs_vector, int grid_type, int hash_bins ){
+	// Variables
+	double f;
+	NuclideGridPoint * low, * high;
+
+	// If using only the nuclide grid, we must perform a binary search
+	// to find the energy location in this particular nuclide's grid.
+	if( grid_type == NUCLIDE )
+	{
+		// Perform binary search on the Nuclide Grid to find the index
+		idx = grid_search_nuclide( n_gridpoints, p_energy, &nuclide_grids[nuc*n_gridpoints], 0, n_gridpoints-1);
+
+		// pull ptr from nuclide grid and check to ensure that
+		// we're not reading off the end of the nuclide's grid
+		if( idx == n_gridpoints - 1 )
+			low = &nuclide_grids[nuc*n_gridpoints + idx - 1];
+		else
+			low = &nuclide_grids[nuc*n_gridpoints + idx];
+	}
+	else if( grid_type == UNIONIZED) // Unionized Energy Grid - we already know the index, no binary search needed.
+	{
+		// pull ptr from energy grid and check to ensure that
+		// we're not reading off the end of the nuclide's grid
+		if( index_data[idx * n_isotopes + nuc] == n_gridpoints - 1 )
+			low = &nuclide_grids[nuc*n_gridpoints + index_data[idx * n_isotopes + nuc] - 1];
+		else
+			low = &nuclide_grids[nuc*n_gridpoints + index_data[idx * n_isotopes + nuc]];
+	}
+	else // Hash grid
+	{
+		// load lower bounding index
+		int u_low = index_data[idx * n_isotopes + nuc];
+
+		// Determine higher bounding index
+		int u_high;
+		if( idx == hash_bins - 1 )
+			u_high = n_gridpoints - 1;
+		else
+			u_high = index_data[(idx+1)*n_isotopes + nuc] + 1;
+
+		// Check edge cases to make sure energy is actually between these
+		// Then, if things look good, search for gridpoint in the nuclide grid
+		// within the lower and higher limits we've calculated.
+		double e_low  = nuclide_grids[nuc*n_gridpoints + u_low].energy;
+		double e_high = nuclide_grids[nuc*n_gridpoints + u_high].energy;
+		int lower;
+		if( p_energy <= e_low )
+			lower = 0;
+		else if( p_energy >= e_high )
+			lower = n_gridpoints - 1;
+		else
+			lower = grid_search_nuclide( n_gridpoints, p_energy, &nuclide_grids[nuc*n_gridpoints], u_low, u_high);
+
+		if( lower == n_gridpoints - 1 )
+			low = &nuclide_grids[nuc*n_gridpoints + lower - 1];
+		else
+			low = &nuclide_grids[nuc*n_gridpoints + lower];
+	}
+
+	high = low + 1;
+
+	// calculate the re-useable interpolation factor
+	f = (high->energy - p_energy) / (high->energy - low->energy);
+
+	// Total XS
+	xs_vector[0] = high->total_xs - f * (high->total_xs - low->total_xs);
+
+	// Elastic XS
+	xs_vector[1] = high->elastic_xs - f * (high->elastic_xs - low->elastic_xs);
+
+	// Absorbtion XS
+	xs_vector[2] = high->absorbtion_xs - f * (high->absorbtion_xs - low->absorbtion_xs);
+
+	// Fission XS
+	xs_vector[3] = high->fission_xs - f * (high->fission_xs - low->fission_xs);
+
+	// Nu Fission XS
+	xs_vector[4] = high->nu_fission_xs - f * (high->nu_fission_xs - low->nu_fission_xs);
+
+	//test
+	/*
+	if( omp_get_thread_num() == 0 )
+	{
+		printf("Lookup: Energy = %lf, nuc = %d\n", p_energy, nuc);
+		printf("e_h = %lf e_l = %lf\n", high->energy , low->energy);
+		printf("xs_h = %lf xs_l = %lf\n", high->elastic_xs, low->elastic_xs);
+		printf("total_xs = %lf\n\n", xs_vector[1]);
+	}
+	*/
+
+}
+
+// Calculates macroscopic cross section based on a given material & energy
+void calculate_macro_xs( double p_energy, int mat, long n_isotopes,
+                         long n_gridpoints, int *  num_nucs,
+                         double *  concs,
+                         double *  egrid, int *  index_data,
+                         NuclideGridPoint *  nuclide_grids,
+                         int *  mats,
+                         double *  macro_xs_vector, int grid_type, int hash_bins, int max_num_nucs ){
+	int p_nuc; // the nuclide we are looking up
+	long idx = -1;
+	double conc; // the concentration of the nuclide in the material
+
+	// cleans out macro_xs_vector
+	for( int k = 0; k < 5; k++ )
+		macro_xs_vector[k] = 0;
+
+	// If we are using the unionized energy grid (UEG), we only
+	// need to perform 1 binary search per macroscopic lookup.
+	// If we are using the nuclide grid search, it will have to be
+	// done inside of the "calculate_micro_xs" function for each different
+	// nuclide in the material.
+	if( grid_type == UNIONIZED )
+		idx = grid_search( n_isotopes * n_gridpoints, p_energy, egrid);
+	else if( grid_type == HASH )
+	{
+		double du = 1.0 / hash_bins;
+		idx = p_energy / du;
+	}
+
+	// Once we find the pointer array on the UEG, we can pull the data
+	// from the respective nuclide grids, as well as the nuclide
+	// concentration data for the material
+	// Each nuclide from the material needs to have its micro-XS array
+	// looked up & interpolatied (via calculate_micro_xs). Then, the
+	// micro XS is multiplied by the concentration of that nuclide
+	// in the material, and added to the total macro XS array.
+	// (Independent -- though if parallelizing, must use atomic operations
+	//  or otherwise control access to the xs_vector and macro_xs_vector to
+	//  avoid simulataneous writing to the same data structure)
+	for( int j = 0; j < num_nucs[mat]; j++ )
+	{
+		double xs_vector[5];
+		p_nuc = mats[mat*max_num_nucs + j];
+		conc = concs[mat*max_num_nucs + j];
+		calculate_micro_xs( p_energy, p_nuc, n_isotopes,
+		                    n_gridpoints, egrid, index_data,
+		                    nuclide_grids, idx, xs_vector, grid_type, hash_bins );
+		for( int k = 0; k < 5; k++ )
+			macro_xs_vector[k] += xs_vector[k] * conc;
+	}
+
+	//test
+	/*
+	for( int k = 0; k < 5; k++ )
+		printf("Energy: %lf, Material: %d, XSVector[%d]: %lf\n",
+		       p_energy, mat, k, macro_xs_vector[k]);
+			   */
+}
+
+
+// binary search for energy on unionized energy grid
+// returns lower index
+long grid_search( long n, double quarry, double *  A)
+{
+	long lowerLimit = 0;
+	long upperLimit = n-1;
+	long examinationPoint;
+	long length = upperLimit - lowerLimit;
+
+	while( length > 1 )
+	{
+		examinationPoint = lowerLimit + ( length / 2 );
+
+		if( A[examinationPoint] > quarry )
+			upperLimit = examinationPoint;
+		else
+			lowerLimit = examinationPoint;
+
+		length = upperLimit - lowerLimit;
+	}
+
+	return lowerLimit;
+}
+
+// binary search for energy on nuclide energy grid
+long grid_search_nuclide( long n, double quarry, NuclideGridPoint * A, long low, long high)
+{
+	long lowerLimit = low;
+	long upperLimit = high;
+	long examinationPoint;
+	long length = upperLimit - lowerLimit;
+
+	while( length > 1 )
+	{
+		examinationPoint = lowerLimit + ( length / 2 );
+
+		if( A[examinationPoint].energy > quarry )
+			upperLimit = examinationPoint;
+		else
+			lowerLimit = examinationPoint;
+
+		length = upperLimit - lowerLimit;
+	}
+
+	return lowerLimit;
+}
+
+// picks a material based on a probabilistic distribution
+int pick_mat( uint64_t * seed )
+{
+	// I have a nice spreadsheet supporting these numbers. They are
+	// the fractions (by volume) of material in the core. Not a
+	// *perfect* approximation of where XS lookups are going to occur,
+	// but this will do a good job of biasing the system nonetheless.
+
+	// Also could be argued that doing fractions by weight would be
+	// a better approximation, but volume does a good enough job for now.
+
+	double dist[12];
+	dist[0]  = 0.140;	// fuel
+	dist[1]  = 0.052;	// cladding
+	dist[2]  = 0.275;	// cold, borated water
+	dist[3]  = 0.134;	// hot, borated water
+	dist[4]  = 0.154;	// RPV
+	dist[5]  = 0.064;	// Lower, radial reflector
+	dist[6]  = 0.066;	// Upper reflector / top plate
+	dist[7]  = 0.055;	// bottom plate
+	dist[8]  = 0.008;	// bottom nozzle
+	dist[9]  = 0.015;	// top nozzle
+	dist[10] = 0.025;	// top of fuel assemblies
+	dist[11] = 0.013;	// bottom of fuel assemblies
+
+	double roll = LCG_random_double(seed);
+
+	// makes a pick based on the distro
+	for( int i = 0; i < 12; i++ )
+	{
+		double running = 0;
+		for( int j = i; j > 0; j-- )
+			running += dist[j];
+		if( roll < running )
+			return i;
+	}
+
+	return 0;
+}
+
+double LCG_random_double(uint64_t * seed)
+{
+	// LCG parameters
+	const uint64_t m = 9223372036854775808ULL; // 2^63
+	const uint64_t a = 2806196910506780709ULL;
+	const uint64_t c = 1ULL;
+	*seed = (a * (*seed) + c) % m;
+	return (double) (*seed) / (double) m;
+	//return ldexp(*seed, -63);
+
+}
+
+uint64_t fast_forward_LCG(uint64_t seed, uint64_t n)
+{
+	// LCG parameters
+	const uint64_t m = 9223372036854775808ULL; // 2^63
+	uint64_t a = 2806196910506780709ULL;
+	uint64_t c = 1ULL;
+
+	n = n % m;
+
+	uint64_t a_new = 1;
+	uint64_t c_new = 0;
+
+	while(n > 0)
+	{
+		if(n & 1)
+		{
+			a_new *= a;
+			c_new = c_new * a + c;
+		}
+		c *= (a + 1);
+		a *= a;
+
+		n >>= 1;
+	}
+
+	return (a_new * seed + c_new) % m;
+
+}

--- a/targets/XSBench/openmp-offload/XSbench_header.h
+++ b/targets/XSBench/openmp-offload/XSbench_header.h
@@ -1,0 +1,116 @@
+#ifndef __XSBENCH_HEADER_H__
+#define __XSBENCH_HEADER_H__
+
+#include<stdio.h>
+#include<stdlib.h>
+#include<time.h>
+#include<string.h>
+#include<strings.h>
+#include<math.h>
+#include<omp.h>
+#include<unistd.h>
+#include<sys/time.h>
+#include<assert.h>
+#include<stdint.h>
+#include "../XSbench_shared_header.h"
+
+// Papi Header
+#ifdef PAPI
+#include "papi.h"
+#endif
+
+// Grid types
+#define UNIONIZED 0
+#define NUCLIDE 1
+#define HASH 2
+
+// Simulation types
+#define HISTORY_BASED 1
+#define EVENT_BASED 2
+
+// Binary Mode Type
+#define NONE 0
+#define READ 1
+#define WRITE 2
+
+// Starting Seed
+#define STARTING_SEED 1070
+
+// Structures
+typedef struct{
+	double energy;
+	double total_xs;
+	double elastic_xs;
+	double absorbtion_xs;
+	double fission_xs;
+	double nu_fission_xs;
+} NuclideGridPoint;
+
+typedef struct{
+	int * num_nucs;                     // Length = length_num_nucs;
+	double * concs;                     // Length = length_concs
+	int * mats;                         // Length = length_mats
+	double * unionized_energy_array;    // Length = length_unionized_energy_array
+	int * index_grid;                   // Length = length_index_grid
+	NuclideGridPoint * nuclide_grid;    // Length = length_nuclide_grid
+	int length_num_nucs;
+	int length_concs;
+	int length_mats;
+	int length_unionized_energy_array;
+	long length_index_grid;
+	int length_nuclide_grid;
+	int max_num_nucs;
+	double * p_energy_samples;
+	int length_p_energy_samples;
+	int * mat_samples;
+	int length_mat_samples;
+} SimulationData;
+
+// io.c
+void logo(int version);
+void center_print(const char *s, int width);
+void border_print(void);
+void fancy_int(long a);
+Inputs read_CLI( int argc, char * argv[] );
+void print_CLI_error(void);
+void print_inputs(Inputs in, int nprocs, int version);
+int print_results( Inputs in, int mype, double runtime, int nprocs, unsigned long long vhash );
+void binary_write( Inputs in, SimulationData SD );
+SimulationData binary_read( Inputs in );
+
+// Simulation.c
+unsigned long long run_event_based_simulation(Inputs in, SimulationData SD, int mype, Profile* profile);
+unsigned long long run_history_based_simulation(Inputs in, SimulationData SD, int mype);
+void calculate_micro_xs(   double p_energy, int nuc, long n_isotopes,
+                           long n_gridpoints,
+                           double *  egrid, int *  index_data,
+                           NuclideGridPoint *  nuclide_grids,
+                           long idx, double *  xs_vector, int grid_type, int hash_bins );
+void calculate_macro_xs( double p_energy, int mat, long n_isotopes,
+                         long n_gridpoints, int *  num_nucs,
+                         double *  concs,
+                         double *  egrid, int *  index_data,
+                         NuclideGridPoint *  nuclide_grids,
+                         int *  mats,
+                         double *  macro_xs_vector, int grid_type, int hash_bins, int max_num_nucs );
+long grid_search( long n, double quarry, double *  A);
+long grid_search_nuclide( long n, double quarry, NuclideGridPoint * A, long low, long high);
+int pick_mat( uint64_t * seed );
+double LCG_random_double(uint64_t * seed);
+uint64_t fast_forward_LCG(uint64_t seed, uint64_t n);
+unsigned long long run_event_based_simulation_optimization_1(Inputs in, SimulationData SD, int mype);
+
+// GridInit.c
+SimulationData grid_init_do_not_profile( Inputs in, int mype );
+
+// XSutils.c
+int NGP_compare( const void * a, const void * b );
+int double_compare(const void * a, const void * b);
+size_t estimate_mem_usage( Inputs in );
+double get_time(void);
+
+// Materials.c
+int * load_num_nucs(long n_isotopes);
+int * load_mats( int * num_nucs, long n_isotopes, int * max_num_nucs );
+double * load_concs( int * num_nucs, int max_num_nucs );
+#endif

--- a/targets/XSBench/openmp-offload/XSutils.c
+++ b/targets/XSBench/openmp-offload/XSutils.c
@@ -1,0 +1,63 @@
+#include "XSbench_header.h"
+
+int double_compare(const void * a, const void * b)
+{
+	double A = *((double *) a);
+	double B = *((double *) b);
+
+	if( A > B )
+		return 1;
+	else if( A < B )
+		return -1;
+	else
+		return 0;
+}
+
+int NGP_compare(const void * a, const void * b)
+{
+	NuclideGridPoint A = *((NuclideGridPoint *) a);
+	NuclideGridPoint B = *((NuclideGridPoint *) b);
+
+	if( A.energy > B.energy )
+		return 1;
+	else if( A.energy < B.energy )
+		return -1;
+	else
+		return 0;
+}
+
+
+size_t estimate_mem_usage( Inputs in )
+{
+	size_t single_nuclide_grid = in.n_gridpoints * sizeof( NuclideGridPoint );
+	size_t all_nuclide_grids   = in.n_isotopes * single_nuclide_grid;
+	size_t size_UEG            = in.n_isotopes*in.n_gridpoints*sizeof(double) + in.n_isotopes*in.n_gridpoints*in.n_isotopes*sizeof(int);
+	size_t size_hash_grid      = in.hash_bins * in.n_isotopes * sizeof(int);
+	size_t memtotal;
+
+	if( in.grid_type == UNIONIZED )
+		memtotal          = all_nuclide_grids + size_UEG;
+	else if( in.grid_type == NUCLIDE )
+		memtotal          = all_nuclide_grids;
+	else
+		memtotal          = all_nuclide_grids + size_hash_grid;
+
+	memtotal          = ceil(memtotal / (1024.0*1024.0));
+	return memtotal;
+}
+
+double get_time(void)
+{
+#ifdef MPI
+	return MPI_Wtime();
+#endif
+
+	struct timeval timecheck;
+
+	gettimeofday(&timecheck, NULL);
+	long ms = (long)timecheck.tv_sec * 1000 + (long)timecheck.tv_usec / 1000;
+
+	double time = (double) ms / 1000.0;
+
+	return time;
+}

--- a/targets/XSBench/openmp-offload/io.c
+++ b/targets/XSBench/openmp-offload/io.c
@@ -1,0 +1,537 @@
+#include "XSbench_header.h"
+
+#ifdef MPI
+#include<mpi.h>
+#endif
+
+// Prints program logo
+void logo(int version)
+{
+	border_print();
+	printf(
+	"                   __   __ ___________                 _                        \n"
+	"                   \\ \\ / //  ___| ___ \\               | |                       \n"
+	"                    \\ V / \\ `--.| |_/ / ___ _ __   ___| |__                     \n"
+	"                    /   \\  `--. \\ ___ \\/ _ \\ '_ \\ / __| '_ \\                    \n"
+	"                   / /^\\ \\/\\__/ / |_/ /  __/ | | | (__| | | |                   \n"
+	"                   \\/   \\/\\____/\\____/ \\___|_| |_|\\___|_| |_|                   \n\n"
+	       );
+	border_print();
+	center_print("Developed at Argonne National Laboratory", 79);
+	char v[100];
+	sprintf(v, "Version: %d", version);
+	center_print(v, 79);
+	border_print();
+}
+
+// Prints Section titles in center of 80 char terminal
+void center_print(const char *s, int width)
+{
+	int length = strlen(s);
+	int i;
+	for (i=0; i<=(width-length)/2; i++) {
+		fputs(" ", stdout);
+	}
+	fputs(s, stdout);
+	fputs("\n", stdout);
+}
+
+int print_results( Inputs in, int mype, double runtime, int nprocs,
+	unsigned long long vhash )
+{
+	// Calculate Lookups per sec
+	int lookups = 0;
+	if( in.simulation_method == HISTORY_BASED )
+		lookups = in.lookups * in.particles;
+	else if( in.simulation_method == EVENT_BASED )
+		lookups = in.lookups;
+	int lookups_per_sec = (int) ((double) lookups / runtime);
+
+	// If running in MPI, reduce timing statistics and calculate average
+	#ifdef MPI
+	int total_lookups = 0;
+	MPI_Barrier(MPI_COMM_WORLD);
+	MPI_Reduce(&lookups_per_sec, &total_lookups, 1, MPI_INT,
+		   MPI_SUM, 0, MPI_COMM_WORLD);
+	#endif
+
+	int is_invalid_result = 1;
+
+	// Print output
+	if( mype == 0 )
+	{
+		border_print();
+		center_print("RESULTS", 79);
+		border_print();
+
+		// Print the results
+		printf("NOTE: Timings are estimated -- use nvprof/nsys/iprof/rocprof for formal analysis\n");
+		#ifdef MPI
+		printf("MPI ranks:   %d\n", nprocs);
+		#endif
+		#ifdef MPI
+		printf("Total Lookups/s:            ");
+		fancy_int(total_lookups);
+		printf("Avg Lookups/s per MPI rank: ");
+		fancy_int(total_lookups / nprocs);
+		#else
+		printf("Runtime:     %.3lf seconds\n", runtime);
+		printf("Lookups:     "); fancy_int(lookups);
+		printf("Lookups/s:   ");
+		fancy_int(lookups_per_sec);
+		#endif
+	}
+
+	unsigned long long large = 0;
+	unsigned long long small = 0;
+	if( in.simulation_method == EVENT_BASED )
+	{
+		small = 945990;
+		large = 952131;
+	}
+	else if( in.simulation_method == HISTORY_BASED )
+	{
+		small = 941535;
+		large = 954318;
+	}
+	if( strcmp(in.HM, "large") == 0 )
+	{
+		if( vhash == large )
+			is_invalid_result = 0;
+	}
+	else if( strcmp(in.HM, "small") == 0 )
+	{
+		if( vhash == small )
+			is_invalid_result = 0;
+	}
+
+	if(mype == 0 )
+	{
+		if( is_invalid_result )
+			printf("Verification checksum: %llu (WARNING - INAVALID CHECKSUM!)\n", vhash);
+		else
+			printf("Verification checksum: %llu (Valid)\n", vhash);
+		border_print();
+	}
+
+	return is_invalid_result;
+}
+
+void print_inputs(Inputs in, int nprocs, int version )
+{
+	// Calculate Estimate of Memory Usage
+	int mem_tot = estimate_mem_usage( in );
+	logo(version);
+	center_print("INPUT SUMMARY", 79);
+	border_print();
+	printf("Programming Model:            OpenMP Target Offloading\n");
+	if( in.simulation_method == EVENT_BASED )
+		printf("Simulation Method:            Event Based\n");
+	else
+		printf("Simulation Method:            History Based\n");
+	if( in.grid_type == NUCLIDE )
+		printf("Grid Type:                    Nuclide Grid\n");
+	else if( in.grid_type == UNIONIZED )
+		printf("Grid Type:                    Unionized Grid\n");
+	else
+		printf("Grid Type:                    Hash\n");
+
+	printf("Materials:                    %d\n", 12);
+	printf("H-M Benchmark Size:           %s\n", in.HM);
+	printf("Total Nuclides:               %ld\n", in.n_isotopes);
+	printf("Gridpoints (per Nuclide):     ");
+	fancy_int(in.n_gridpoints);
+	if( in.grid_type == HASH )
+	{
+		printf("Hash Bins:                    ");
+		fancy_int(in.hash_bins);
+	}
+	if( in.grid_type == UNIONIZED )
+	{
+		printf("Unionized Energy Gridpoints:  ");
+		fancy_int(in.n_isotopes*in.n_gridpoints);
+	}
+	if( in.simulation_method == HISTORY_BASED )
+	{
+		printf("Particle Histories:           "); fancy_int(in.particles);
+		printf("XS Lookups per Particle:      "); fancy_int(in.lookups);
+	}
+	printf("Total XS Lookups:             "); fancy_int(in.lookups);
+	printf("Total XS Iterations:          "); fancy_int(in.num_iterations);
+	#ifdef MPI
+	printf("MPI Ranks:                    %d\n", nprocs);
+	printf("Mem Usage per MPI Rank (MB):  "); fancy_int(mem_tot);
+	#else
+	printf("Est. Memory Usage (MB):       "); fancy_int(mem_tot);
+	#endif
+	printf("Binary File Mode:             ");
+	if( in.binary_mode == NONE )
+		printf("Off\n");
+	else if( in.binary_mode == READ)
+		printf("Read\n");
+	else
+		printf("Write\n");
+	border_print();
+	center_print("INITIALIZATION - DO NOT PROFILE", 79);
+	border_print();
+}
+
+void border_print(void)
+{
+	printf(
+	"==================================================================="
+	"=============\n");
+}
+
+// Prints comma separated integers - for ease of reading
+void fancy_int( long a )
+{
+    if( a < 1000 )
+	printf("%ld\n",a);
+
+    else if( a >= 1000 && a < 1000000 )
+	printf("%ld,%03ld\n", a / 1000, a % 1000);
+
+    else if( a >= 1000000 && a < 1000000000 )
+	printf("%ld,%03ld,%03ld\n",a / 1000000,(a % 1000000) / 1000,a % 1000 );
+
+    else if( a >= 1000000000 )
+	printf("%ld,%03ld,%03ld,%03ld\n",
+	       a / 1000000000,
+	       (a % 1000000000) / 1000000,
+	       (a % 1000000) / 1000,
+	       a % 1000 );
+    else
+	printf("%ld\n",a);
+}
+
+void print_CLI_error(void)
+{
+	printf("Usage: ./XSBench <options>\n");
+	printf("Options include:\n");
+	printf("  -m <simulation method>   Simulation method (history, event)\n");
+	printf("  -s <size>                Size of H-M Benchmark to run (small, large, XL, XXL)\n");
+	printf("  -g <gridpoints>          Number of gridpoints per nuclide (overrides -s defaults)\n");
+	printf("  -G <grid type>           Grid search type (unionized, nuclide, hash). Defaults to unionized.\n");
+	printf("  -p <particles>           Number of particle histories\n");
+	printf("  -l <lookups>             History Based: Number of Cross-section (XS) lookups per particle. Event Based: Total number of XS lookups.\n");
+	printf("  -h <hash bins>           Number of hash bins (only relevant when used with \"-G hash\")\n");
+	printf("  -b <binary mode>         Read or write all data structures to file. If reading, this will skip initialization phase. (read, write)\n");
+	printf("  -k <kernel ID>           Specifies which kernel to run. 0 is baseline, 1, 2, etc are optimized variants. (0 is default.)\n");
+	printf("  -n <num iterations>      Specifies how many kernel iterations to run. (1 is default.)\n");
+	printf("Default is equivalent to: -m history -s large -l 34 -p 500000 -G unionized -n 1\n");
+	printf("See readme for full description of default run values\n");
+	exit(4);
+}
+
+Inputs read_CLI( int argc, char * argv[] )
+{
+	Inputs input;
+
+	// defaults to the history based simulation method
+	input.simulation_method = HISTORY_BASED;
+
+	// defaults to max threads on the system
+	input.nthreads = omp_get_num_procs();
+
+	// defaults to 355 (corresponding to H-M Large benchmark)
+	input.n_isotopes = 355;
+
+	// defaults to 11303 (corresponding to H-M Large benchmark)
+	input.n_gridpoints = 11303;
+
+	// defaults to 500,000
+	input.particles = 500000;
+
+	// defaults to 34
+	input.lookups = 34;
+
+	// default to unionized grid
+	input.grid_type = UNIONIZED;
+
+	// default to unionized grid
+	input.hash_bins = 10000;
+
+	// default to no binary read/write
+	input.binary_mode = NONE;
+
+	// defaults to baseline kernel
+	input.kernel_id = 0;
+
+	// default to one kernel iteration
+	input.num_iterations = 1;
+
+  // default to zero warmup iterations
+	input.num_warmups = 1;
+
+  // default to stdout
+  input.filename = NULL;
+
+	// defaults to H-M Large benchmark
+	input.HM = (char *) malloc( 6 * sizeof(char) );
+	input.HM[0] = 'l' ;
+	input.HM[1] = 'a' ;
+	input.HM[2] = 'r' ;
+	input.HM[3] = 'g' ;
+	input.HM[4] = 'e' ;
+	input.HM[5] = '\0';
+
+	// Check if user sets these
+	int user_g = 0;
+
+	int default_lookups = 1;
+	int default_particles = 1;
+   
+	// Collect Raw Input
+	for( int i = 1; i < argc; i++ )
+	{
+		char * arg = argv[i];
+
+		// n_gridpoints (-g)
+		if( strcmp(arg, "-g") == 0 )
+		{
+			if( ++i < argc )
+			{
+				user_g = 1;
+				input.n_gridpoints = atol(argv[i]);
+			}
+			else
+				print_CLI_error();
+		}
+		// Simulation Method (-m)
+		else if( strcmp(arg, "-m") == 0 )
+		{
+			char * sim_type;
+			if( ++i < argc )
+				sim_type = argv[i];
+			else
+				print_CLI_error();
+
+			if( strcmp(sim_type, "history") == 0 )
+				input.simulation_method = HISTORY_BASED;
+			else if( strcmp(sim_type, "event") == 0 )
+			{
+				input.simulation_method = EVENT_BASED;
+				// Also resets default # of lookups
+				if( default_lookups && default_particles )
+				{
+					input.lookups =  input.lookups * input.particles;
+					input.particles = 0;
+				}
+			}
+			else
+				print_CLI_error();
+		}
+		// lookups (-l)
+		else if( strcmp(arg, "-l") == 0 )
+		{
+			if( ++i < argc )
+			{
+				input.lookups = atoi(argv[i]);
+				default_lookups = 0;
+			}
+			else
+				print_CLI_error();
+		}
+		// hash bins (-h)
+		else if( strcmp(arg, "-h") == 0 )
+		{
+			if( ++i < argc )
+				input.hash_bins = atoi(argv[i]);
+			else
+				print_CLI_error();
+		}
+		// particles (-p)
+		else if( strcmp(arg, "-p") == 0 )
+		{
+			if( ++i < argc )
+			{
+				input.particles = atoi(argv[i]);
+				default_particles = 0;
+			}
+			else
+				print_CLI_error();
+		}
+		// HM (-s)
+		else if( strcmp(arg, "-s") == 0 )
+		{
+			if( ++i < argc )
+				input.HM = argv[i];
+			else
+				print_CLI_error();
+		}
+		// grid type (-G)
+		else if( strcmp(arg, "-G") == 0 )
+		{
+			char * grid_type;
+			if( ++i < argc )
+				grid_type = argv[i];
+			else
+				print_CLI_error();
+
+			if( strcmp(grid_type, "unionized") == 0 )
+				input.grid_type = UNIONIZED;
+			else if( strcmp(grid_type, "nuclide") == 0 )
+				input.grid_type = NUCLIDE;
+			else if( strcmp(grid_type, "hash") == 0 )
+				input.grid_type = HASH;
+			else
+				print_CLI_error();
+		}
+		// binary mode (-b)
+		else if( strcmp(arg, "-b") == 0 )
+		{
+			char * binary_mode;
+			if( ++i < argc )
+				binary_mode = argv[i];
+			else
+				print_CLI_error();
+
+			if( strcmp(binary_mode, "read") == 0 )
+				input.binary_mode = READ;
+			else if( strcmp(binary_mode, "write") == 0 )
+				input.binary_mode = WRITE;
+			else
+				print_CLI_error();
+		}
+		// kernel optimization selection (-k)
+		else if( strcmp(arg, "-k") == 0 )
+		{
+			if( ++i < argc )
+			{
+				input.kernel_id = atoi(argv[i]);
+			}
+			else
+				print_CLI_error();
+		}
+		// number of kernel iterations (-n)
+		else if( strcmp(arg, "-n") == 0 )
+		{
+			if( ++i < argc)
+			{
+				input.num_iterations = atoi(argv[i]);
+			}
+			else
+				print_CLI_error();
+		}
+		else if( strcmp(arg, "--csv") == 0 )
+		{
+			if( ++i < argc ) {
+        input.filename = (char *)malloc(strlen(argv[i]) + 1);
+        strcpy(input.filename, argv[i]);
+      }
+			else
+				print_CLI_error();
+    }
+		else if( strcmp(arg, "-w") == 0 )
+		{
+			if( ++i < argc)
+			{
+				input.num_warmups = atoi(argv[i]);
+			}
+			else
+				print_CLI_error();
+		}
+		else
+			print_CLI_error();
+	}
+
+	// Validate Input
+
+	// Validate nthreads
+	if( input.nthreads < 1 )
+		print_CLI_error();
+
+	// Validate n_isotopes
+	if( input.n_isotopes < 1 )
+		print_CLI_error();
+
+	// Validate n_gridpoints
+	if( input.n_gridpoints < 1 )
+		print_CLI_error();
+
+	// Validate lookups
+	if( input.lookups < 1 )
+		print_CLI_error();
+
+	// Validate Hash Bins
+	if( input.hash_bins < 1 )
+		print_CLI_error();
+
+	// Validate number of iterations
+	if ( input.num_iterations < 1 )
+		print_CLI_error();
+
+	// Validate HM size
+	if( strcasecmp(input.HM, "small") != 0 &&
+		strcasecmp(input.HM, "large") != 0 &&
+		strcasecmp(input.HM, "XL") != 0 &&
+		strcasecmp(input.HM, "XXL") != 0 )
+		print_CLI_error();
+
+	// Set HM size specific parameters
+	// (defaults to large)
+	if( strcasecmp(input.HM, "small") == 0 )
+		input.n_isotopes = 68;
+	else if( strcasecmp(input.HM, "XL") == 0 && user_g == 0 )
+		input.n_gridpoints = 238847; // sized to make 120 GB XS data
+	else if( strcasecmp(input.HM, "XXL") == 0 && user_g == 0 )
+		input.n_gridpoints = 238847 * 2.1; // 252 GB XS data
+
+	// Return input struct
+	return input;
+}
+
+void binary_write( Inputs in, SimulationData SD )
+{
+	char * fname = "XS_data.dat";
+	printf("Writing all data structures to binary file %s...\n", fname);
+	FILE * fp = fopen(fname, "w");
+
+	// Write SimulationData Object. Include pointers, even though we won't be using them.
+	fwrite(&SD, sizeof(SimulationData), 1, fp);
+
+	// Write heap arrays in SimulationData Object
+	fwrite(SD.num_nucs,       sizeof(int), SD.length_num_nucs, fp);
+	fwrite(SD.concs,          sizeof(double), SD.length_concs, fp);
+	fwrite(SD.mats,           sizeof(int), SD.length_mats, fp);
+	fwrite(SD.nuclide_grid,   sizeof(NuclideGridPoint), SD.length_nuclide_grid, fp);
+	fwrite(SD.index_grid, sizeof(int), SD.length_index_grid, fp);
+	fwrite(SD.unionized_energy_array, sizeof(double), SD.length_unionized_energy_array, fp);
+
+	fclose(fp);
+}
+
+SimulationData binary_read( Inputs in )
+{
+	SimulationData SD;
+
+	char * fname = "XS_data.dat";
+	printf("Reading all data structures from binary file %s...\n", fname);
+
+	FILE * fp = fopen(fname, "r");
+	assert(fp != NULL);
+
+	// Read SimulationData Object. Include pointers, even though we won't be using them.
+	fread(&SD, sizeof(SimulationData), 1, fp);
+
+	// Allocate space for arrays on heap
+	SD.num_nucs = (int *) malloc(SD.length_num_nucs * sizeof(int));
+	SD.concs = (double *) malloc(SD.length_concs * sizeof(double));
+	SD.mats = (int *) malloc(SD.length_mats * sizeof(int));
+	SD.nuclide_grid = (NuclideGridPoint *) malloc(SD.length_nuclide_grid * sizeof(NuclideGridPoint));
+	SD.index_grid = (int *) malloc( SD.length_index_grid * sizeof(int));
+	SD.unionized_energy_array = (double *) malloc( SD.length_unionized_energy_array * sizeof(double));
+
+	// Read heap arrays into SimulationData Object
+	fread(SD.num_nucs,       sizeof(int), SD.length_num_nucs, fp);
+	fread(SD.concs,          sizeof(double), SD.length_concs, fp);
+	fread(SD.mats,           sizeof(int), SD.length_mats, fp);
+	fread(SD.nuclide_grid,   sizeof(NuclideGridPoint), SD.length_nuclide_grid, fp);
+	fread(SD.index_grid, sizeof(int), SD.length_index_grid, fp);
+	fread(SD.unionized_energy_array, sizeof(double), SD.length_unionized_energy_array, fp);
+
+	fclose(fp);
+
+	return SD;
+}


### PR DESCRIPTION
This is the CUDA, OMP offload, and Kokkos versions of XSBench, taken from our fork. The Kokkos version was created by me but the repository hosting it is public, unfortunately. This may still be useful though as an early, smaller test case.

Additionally, there are CMake and GNU make build systems for the OMP and CUDA versions, so we might be able to do some testing with which build system gets better results.